### PR TITLE
Add additonal HWRM debug info to error messages

### DIFF
--- a/drivers/net/bnxt/bnxt_hwrm.c
+++ b/drivers/net/bnxt/bnxt_hwrm.c
@@ -137,9 +137,20 @@ static int bnxt_hwrm_send_message(struct bnxt *bp, void *msg, uint32_t msg_len)
 			return rc; \
 		} \
 		if (resp->error_code) { \
-			rc = rte_le_to_cpu_16(resp->error_code); \
-			RTE_LOG(ERR, PMD, "%s error %d\n", __func__, rc); \
-			return rc; \
+			if (resp->resp_len >= 16) { \
+				struct hwrm_err_output *tmp_hwrm_err_output = (void *)resp; \
+				rc = rte_le_to_cpu_16(resp->error_code); \
+				RTE_LOG(ERR, PMD, "%s error %d:%d:%08x:%04x\n", __func__, \
+					rc, tmp_hwrm_err_output->cmd_err, \
+					rte_le_to_cpu_32(tmp_hwrm_err_output->opaque_0), \
+					rte_le_to_cpu_16(tmp_hwrm_err_output->opaque_1)); \
+				return rc; \
+			} \
+			else { \
+				rc = rte_le_to_cpu_16(resp->error_code); \
+				RTE_LOG(ERR, PMD, "%s error %d\n", __func__, rc); \
+				return rc; \
+			} \
 		} \
 	}
 

--- a/drivers/net/bnxt/hsi_struct_def_dpdk.h
+++ b/drivers/net/bnxt/hsi_struct_def_dpdk.h
@@ -1318,6 +1318,42 @@ struct output {
 	 */
 } __attribute__((packed));
 
+/* Output (16 bytes) */
+struct hwrm_err_output {
+    uint16_t error_code;
+    /*
+     * Pass/Fail or error type Note: receiver to verify the in parameters,
+     * and fail the call with an error when appropriate
+     */
+    uint16_t req_type;
+    /* This field returns the type of original request. */
+    uint16_t seq_id;
+    /* This field provides original sequence number of the command. */
+    uint16_t resp_len;
+    /*
+     * This field is the length of the response in bytes. The last byte of
+     * the response is a valid flag that will read as '1' when the command
+     * has been completely written to memory.
+     */
+    uint32_t opaque_0;
+    /* debug info for this error response. */
+    uint16_t opaque_1;
+    /* debug info for this error response. */
+    uint8_t cmd_err;
+    /*
+     * In the case of an error response, command specific error code is
+     * returned in this field.
+     */
+    uint8_t valid;
+    /*
+     * This field is used in Output records to indicate that the output is
+     * completely written to RAM. This field should be read as '1' to
+     * indicate that the output has been completely written. When writing a
+     * command completion or response to an internal processor, the order of
+     * writes has to be such that this field is written last.
+     */
+} hwrm_err_output_t, *phwrm_err_output_t;
+
 /* hwrm_ver_get */
 /*
  * Description: This function is called by a driver to determine the HWRM


### PR DESCRIPTION
Add the cmd_err and opaque_0 and opaque_1 fields to HWRM error
messages.  These allow better debugging of some classes of HWRM
errors.