### PR TITLE
Support setting VF mac address

### DIFF
--- a/app/test-pmd/cmdline.c
+++ b/app/test-pmd/cmdline.c
@@ -11388,8 +11388,13 @@ cmd_set_vf_mac_addr_parsed(
 {
 	struct cmd_set_vf_mac_addr_result *res = parsed_result;
 	int ret;
+	struct rte_eth_dev *dev = &rte_eth_devices[res->port_id];
 
-	ret = rte_pmd_ixgbe_set_vf_mac_addr(res->port_id, res->vf_id,
+	if (strcmp(dev->driver->pci_drv.driver.name, "net_bnxt") == 0)
+		ret = rte_pmd_bnxt_set_vf_mac_addr(res->port_id, res->vf_id,
+			&res->mac_addr);
+	else
+		ret = rte_pmd_ixgbe_set_vf_mac_addr(res->port_id, res->vf_id,
 			&res->mac_addr);
 	switch (ret) {
 	case 0:

--- a/drivers/net/bnxt/bnxt_cpr.c
+++ b/drivers/net/bnxt/bnxt_cpr.c
@@ -87,7 +87,7 @@ void bnxt_handle_fwd_req(struct bnxt *bp, struct cmpl_base *cmpl)
 		req_len = sizeof(fwreq->encap_request);
 
 	/* Locate VF's forwarded command */
-	fwd_cmd = (struct input *)bp->pf.vf_info[vf_id - bp->pf.first_vf_id].req_buf;
+	fwd_cmd = (struct input *)bp->pf.vf_info[fw_vf_id - bp->pf.first_vf_id].req_buf;
   
 	/* Force the target ID to the source VF */
 	fwd_cmd->target_id = rte_cpu_to_le_16(fw_vf_id);

--- a/drivers/net/bnxt/bnxt_hwrm.c
+++ b/drivers/net/bnxt/bnxt_hwrm.c
@@ -1058,6 +1058,25 @@ int bnxt_hwrm_func_vf_stall(struct bnxt *bp, uint16_t vf, uint8_t on)
 	return rc;
 }
 
+int bnxt_hwrm_func_vf_mac(struct bnxt *bp, uint16_t vf, uint8_t *mac_addr)
+{
+	struct hwrm_func_cfg_input req = {0};
+	struct hwrm_func_cfg_output *resp = bp->hwrm_cmd_resp_addr;
+	int rc;
+
+	req.flags = rte_cpu_to_le_32(bp->pf.vf_info[vf].func_cfg_flags);
+	req.enables = rte_cpu_to_le_32(HWRM_FUNC_CFG_INPUT_ENABLES_DFLT_MAC_ADDR);
+	memcpy(req.dflt_mac_addr, mac_addr, sizeof(req.dflt_mac_addr));
+	req.fid = rte_cpu_to_le_16(bp->pf.vf_info[vf].fid);
+
+	HWRM_PREP(req, FUNC_CFG, -1, resp);
+
+	rc = bnxt_hwrm_send_message(bp, &req, sizeof(req));
+	HWRM_CHECK_RESULT;
+
+	return rc;
+}
+
 int bnxt_hwrm_func_buf_rgtr(struct bnxt *bp)
 {
 	int rc = 0;

--- a/drivers/net/bnxt/bnxt_hwrm.h
+++ b/drivers/net/bnxt/bnxt_hwrm.h
@@ -110,6 +110,7 @@ int bnxt_hwrm_func_qcfg(struct bnxt *bp);
 int bnxt_hwrm_allocate_pf_only(struct bnxt *bp);
 int bnxt_hwrm_allocate_vfs(struct bnxt *bp, int num_vfs);
 int bnxt_hwrm_func_vf_stall(struct bnxt *bp, uint16_t vf, uint8_t on);
+int bnxt_hwrm_func_vf_mac(struct bnxt *bp, uint16_t vf, uint8_t *mac_addr);
 int bnxt_hwrm_pf_evb_mode(struct bnxt *bp);
 
 #endif

--- a/drivers/net/bnxt/rte_pmd_bnxt.c
+++ b/drivers/net/bnxt/rte_pmd_bnxt.c
@@ -62,7 +62,7 @@ int rte_pmd_bnxt_set_tx_loopback(uint8_t port, uint8_t on)
 	bp = (struct bnxt *)eth_dev->data->dev_private;
 
 	if (!BNXT_PF(bp)) {
-		RTE_LOG(ERR, PMD, "Attempt to set PF loopback on none-PF port %d!\n",
+		RTE_LOG(ERR, PMD, "Attempt to set PF loopback on non-PF port %d!\n",
 				port);
 		return -ENOTSUP;
 	}
@@ -93,7 +93,7 @@ int rte_pmd_bnxt_set_all_queues_drop_en(uint8_t port, uint8_t on)
 	bp = (struct bnxt *)eth_dev->data->dev_private;
 
 	if (!BNXT_PF(bp)) {
-		RTE_LOG(ERR, PMD, "Attempt to set all queues drop on none-PF port!\n");
+		RTE_LOG(ERR, PMD, "Attempt to set all queues drop on non-PF port!\n");
 		return -ENOTSUP;
 	}
 
@@ -141,7 +141,7 @@ rte_pmd_bnxt_set_vf_mac_addr(uint8_t port, uint16_t vf,
 		return -EINVAL;
 
 	if (!BNXT_PF(bp)) {
-		RTE_LOG(ERR, PMD, "Attempt to set VF %d mac address on none-PF port %d!\n",
+		RTE_LOG(ERR, PMD, "Attempt to set VF %d mac address on non-PF port %d!\n",
 				vf, port);
 		return -ENOTSUP;
 	}

--- a/drivers/net/bnxt/rte_pmd_bnxt.c
+++ b/drivers/net/bnxt/rte_pmd_bnxt.c
@@ -62,7 +62,8 @@ int rte_pmd_bnxt_set_tx_loopback(uint8_t port, uint8_t on)
 	bp = (struct bnxt *)eth_dev->data->dev_private;
 
 	if (!BNXT_PF(bp)) {
-		RTE_LOG(ERR, PMD, "Attempt to operate on none-PF!\n");
+		RTE_LOG(ERR, PMD, "Attempt to set PF loopback on none-PF port %d!\n",
+				port);
 		return -ENOTSUP;
 	}
 
@@ -117,6 +118,35 @@ int rte_pmd_bnxt_set_all_queues_drop_en(uint8_t port, uint8_t on)
 			break;
 		}
 	}
+
+	return rc;
+}
+
+int
+rte_pmd_bnxt_set_vf_mac_addr(uint8_t port, uint16_t vf,
+		struct ether_addr *mac_addr)
+{
+	struct rte_eth_dev *dev;
+	struct rte_eth_dev_info dev_info;
+	struct bnxt *bp;
+	int rc;
+
+	RTE_ETH_VALID_PORTID_OR_ERR_RET(port, -ENODEV);
+
+	dev = &rte_eth_devices[port];
+	rte_eth_dev_info_get(port, &dev_info);
+	bp = (struct bnxt *)dev->data->dev_private;
+
+	if (vf >= dev_info.max_vfs || mac_addr == NULL)
+		return -EINVAL;
+
+	if (!BNXT_PF(bp)) {
+		RTE_LOG(ERR, PMD, "Attempt to set VF %d mac address on none-PF port %d!\n",
+				vf, port);
+		return -ENOTSUP;
+	}
+
+	rc = bnxt_hwrm_func_vf_mac(bp, vf, (uint8_t *)mac_addr);
 
 	return rc;
 }

--- a/drivers/net/bnxt/rte_pmd_bnxt.h
+++ b/drivers/net/bnxt/rte_pmd_bnxt.h
@@ -69,6 +69,23 @@ int rte_pmd_bnxt_set_tx_loopback(uint8_t port, uint8_t on);
 int rte_pmd_bnxt_set_all_queues_drop_en(uint8_t port, uint8_t on);
 
 /**
+ * Set the VF MAC address.
+ *
+ * @param port
+ *   The port identifier of the Ethernet device.
+ * @param vf
+ *   VF id.
+ * @param mac_addr
+ *   VF MAC address.
+ * @return
+ *   - (0) if successful.
+ *   - (-ENODEV) if *port* invalid.
+ *   - (-EINVAL) if *vf* or *mac_addr* is invalid.
+ */
+int rte_pmd_bnxt_set_vf_mac_addr(uint8_t port, uint16_t vf,
+		struct ether_addr *mac_addr);
+
+/**
  * Response sent back to bnxt driver from user app after callback
  */
 enum rte_pmd_bnxt_mb_event_rsp {


### PR DESCRIPTION
This set mac feature works only work when VF not started, in other words, to setup VF mac, has to stop testpmd that binds to VF. Configure on-the-fly wouldn't work, is this the expected model? 