### PR TITLE
16.11 vf set default vlan

### DIFF
--- a/drivers/net/bnxt/bnxt_hwrm.c
+++ b/drivers/net/bnxt/bnxt_hwrm.c
@@ -1077,6 +1077,31 @@ int bnxt_hwrm_func_vf_mac(struct bnxt *bp, uint16_t vf, uint8_t *mac_addr)
 	return rc;
 }
 
+int bnxt_hwrm_func_vf_dflt_vlan(struct bnxt *bp, uint16_t vf, uint16_t vlan, bool on)
+{
+	struct hwrm_func_cfg_input req = {0};
+	struct hwrm_func_cfg_output *resp = bp->hwrm_cmd_resp_addr;
+	int rc;
+
+	req.flags = rte_cpu_to_le_32(bp->pf.vf_info[vf].func_cfg_flags);
+	req.enables = rte_cpu_to_le_32(HWRM_FUNC_CFG_INPUT_ENABLES_DFLT_VLAN);
+	req.dflt_vlan = rte_cpu_to_le_16(on ? vlan : 0);
+#if 0
+	req.enables |= rte_cpu_to_le_32(HWRM_FUNC_CFG_INPUT_ENABLES_VLAN_ANTISPOOF_MODE);
+	req.vlan_antispoof_mode = on ?
+			HWRM_FUNC_CFG_INPUT_VLAN_ANTISPOOF_MODE_INSERT_OR_OVERRIDE_VLAN :
+			HWRM_FUNC_CFG_INPUT_VLAN_ANTISPOOF_MODE_NOCHECK;
+#endif
+	req.fid = rte_cpu_to_le_16(bp->pf.vf_info[vf].fid);
+
+	HWRM_PREP(req, FUNC_CFG, -1, resp);
+
+	rc = bnxt_hwrm_send_message(bp, &req, sizeof(req));
+	HWRM_CHECK_RESULT;
+
+	return rc;
+}
+
 int bnxt_hwrm_func_buf_rgtr(struct bnxt *bp)
 {
 	int rc = 0;

--- a/drivers/net/bnxt/bnxt_hwrm.h
+++ b/drivers/net/bnxt/bnxt_hwrm.h
@@ -111,6 +111,8 @@ int bnxt_hwrm_allocate_pf_only(struct bnxt *bp);
 int bnxt_hwrm_allocate_vfs(struct bnxt *bp, int num_vfs);
 int bnxt_hwrm_func_vf_stall(struct bnxt *bp, uint16_t vf, uint8_t on);
 int bnxt_hwrm_func_vf_mac(struct bnxt *bp, uint16_t vf, uint8_t *mac_addr);
+int bnxt_hwrm_func_vf_dflt_vlan(struct bnxt *bp, uint16_t vf, uint16_t vlan,
+			bool on);
 int bnxt_hwrm_pf_evb_mode(struct bnxt *bp);
 int bnxt_hwrm_func_bw_cfg(struct bnxt *bp, uint16_t vf,
 			uint16_t max_bw, uint16_t enables);


### PR DESCRIPTION
Set VF default VLAN, to test it:
1: start testpmd with PF only
2: start PF traffic with "start" command - not sure why this command is a must
3: rx_vlan add|rm 99 port 0 vf 1 - bind VF 0 with vlan 99
4: start testpmd with VF
5: run "start tx_first 10"
6: ixia should capture packets with vlan 99 now, and only vlan 99 pkts sent from ixia can be received by VF 0

Seems VFd allows multiple VLAN binding to VF, this might not be able to meet requirements exactly, I remember Hurd is working on CFA solution, feel free to reject if I'm heading wrong.