### PR TITLE
Set the VMDq pool size correctly

### DIFF
--- a/drivers/net/bnxt/bnxt_irq.c
+++ b/drivers/net/bnxt/bnxt_irq.c
@@ -77,6 +77,8 @@ static void bnxt_int_handler(struct rte_intr_handle *handle __rte_unused,
 		}
 		raw_cons = NEXT_RAW_CMP(raw_cons);
 	}
+
+	cpr->cp_raw_cons = raw_cons;
 	B_CP_DB_REARM(cpr, cpr->cp_raw_cons);
 }
 

--- a/drivers/net/bnxt/bnxt_rxq.c
+++ b/drivers/net/bnxt/bnxt_rxq.c
@@ -123,7 +123,7 @@ int bnxt_mq_rx_configure(struct bnxt *bp)
 		if (!pools) {
 			pools = RTE_MIN(bp->max_vnics,
 			    RTE_MIN(bp->max_l2_ctx,
-			     RTE_MIN(bp->max_rsscos_ctx, ETH_64_POOLS))));
+			     RTE_MIN(bp->max_rsscos_ctx, ETH_64_POOLS)));
 			RTE_LOG(ERR, PMD,
 			    "VMDq pool not set, defaulted to %d\n", pools);
 		}

--- a/drivers/net/bnxt/bnxt_rxq.c
+++ b/drivers/net/bnxt/bnxt_rxq.c
@@ -122,8 +122,14 @@ int bnxt_mq_rx_configure(struct bnxt *bp)
 		/* For each pool, allocate MACVLAN CFA rule & VNIC */
 		if (!pools) {
 			RTE_LOG(ERR, PMD,
-				"VMDq pool not set, defaulted to 64\n");
-			pools = ETH_64_POOLS;
+			    "VMDq pool not set, defaulted to %d\n",
+			    RTE_MIN(bp->max_vnics,
+			     RTE_MIN(bp->max_l2_ctx,
+			      RTE_MIN(bp->max_rsscos_ctx, ETH_64_POOLS))));
+			pools = RTE_MIN(bp->max_vnics,
+			    RTE_MIN(bp->max_vnics,
+			     RTE_MIN(bp->max_l2_ctx,
+			      RTE_MIN(bp->max_rsscos_ctx, ETH_64_POOLS))));
 		}
 		nb_q_per_grp = bp->rx_cp_nr_rings / pools;
 		start_grp_id = 1;
@@ -134,7 +140,7 @@ int bnxt_mq_rx_configure(struct bnxt *bp)
 			vnic = bnxt_alloc_vnic(bp);
 			if (!vnic) {
 				RTE_LOG(ERR, PMD,
-					"VNIC alloc failed\n");
+					"VNIC %d alloc failed\n", i);
 				rc = -ENOMEM;
 				goto err_out;
 			}

--- a/drivers/net/bnxt/bnxt_rxq.c
+++ b/drivers/net/bnxt/bnxt_rxq.c
@@ -121,14 +121,11 @@ int bnxt_mq_rx_configure(struct bnxt *bp)
 		}
 		/* For each pool, allocate MACVLAN CFA rule & VNIC */
 		if (!pools) {
-			RTE_LOG(ERR, PMD,
-			    "VMDq pool not set, defaulted to %d\n",
-			    RTE_MIN(bp->max_vnics,
-			     RTE_MIN(bp->max_l2_ctx,
-			      RTE_MIN(bp->max_rsscos_ctx, ETH_64_POOLS))));
 			pools = RTE_MIN(bp->max_vnics,
 			    RTE_MIN(bp->max_l2_ctx,
 			     RTE_MIN(bp->max_rsscos_ctx, ETH_64_POOLS))));
+			RTE_LOG(ERR, PMD,
+			    "VMDq pool not set, defaulted to %d\n", pools);
 		}
 		nb_q_per_grp = bp->rx_cp_nr_rings / pools;
 		start_grp_id = 1;

--- a/drivers/net/bnxt/bnxt_rxq.c
+++ b/drivers/net/bnxt/bnxt_rxq.c
@@ -127,9 +127,8 @@ int bnxt_mq_rx_configure(struct bnxt *bp)
 			     RTE_MIN(bp->max_l2_ctx,
 			      RTE_MIN(bp->max_rsscos_ctx, ETH_64_POOLS))));
 			pools = RTE_MIN(bp->max_vnics,
-			    RTE_MIN(bp->max_vnics,
-			     RTE_MIN(bp->max_l2_ctx,
-			      RTE_MIN(bp->max_rsscos_ctx, ETH_64_POOLS))));
+			    RTE_MIN(bp->max_l2_ctx,
+			     RTE_MIN(bp->max_rsscos_ctx, ETH_64_POOLS))));
 		}
 		nb_q_per_grp = bp->rx_cp_nr_rings / pools;
 		start_grp_id = 1;


### PR DESCRIPTION
Needs to be the minimum of all used resources... vnic, l2 CTX, RSS
CTX, or 64 (hard coded).