### PR TITLE
app/testpmd: Add support to generate geneve and vxlan traffic

### DIFF
--- a/app/test-pmd/cmdline.c
+++ b/app/test-pmd/cmdline.c
@@ -265,6 +265,9 @@ static void cmd_help_long_parsed(void *parsed_result,
 			"set portlist (x[,y]*)\n"
 			"    Set the list of forwarding ports.\n\n"
 
+			"set tunnel (vxlan|geneve|none)\n"
+			"    Set the Tunnel Mode.\n\n"
+
 #ifdef RTE_LIBRTE_IXGBE_PMD
 			"set tx loopback (port_id) (on|off)\n"
 			"    Enable or disable tx loopback.\n\n"
@@ -4733,6 +4736,12 @@ struct cmd_set_fwd_mode_result {
 	cmdline_fixed_string_t mode;
 };
 
+struct cmd_set_tunnel_mode_result {
+	cmdline_fixed_string_t set;
+	cmdline_fixed_string_t tunnel;
+	cmdline_fixed_string_t mode;
+};
+
 static void cmd_set_fwd_mode_parsed(void *parsed_result,
 				    __attribute__((unused)) struct cmdline *cl,
 				    __attribute__((unused)) void *data)
@@ -4743,6 +4752,15 @@ static void cmd_set_fwd_mode_parsed(void *parsed_result,
 	set_pkt_forwarding_mode(res->mode);
 }
 
+static void cmd_set_tunnel_mode_parsed(void *parsed_result,
+				    __attribute__((unused)) struct cmdline *cl,
+				    __attribute__((unused)) void *data)
+{
+	struct cmd_set_tunnel_mode_result *res = parsed_result;
+
+	set_tunnel_mode(res->mode);
+}
+
 cmdline_parse_token_string_t cmd_setfwd_set =
 	TOKEN_STRING_INITIALIZER(struct cmd_set_fwd_mode_result, set, "set");
 cmdline_parse_token_string_t cmd_setfwd_fwd =
@@ -4750,6 +4768,14 @@ cmdline_parse_token_string_t cmd_setfwd_fwd =
 cmdline_parse_token_string_t cmd_setfwd_mode =
 	TOKEN_STRING_INITIALIZER(struct cmd_set_fwd_mode_result, mode,
 		"" /* defined at init */);
+
+cmdline_parse_token_string_t cmd_settunnel_set =
+	TOKEN_STRING_INITIALIZER(struct cmd_set_tunnel_mode_result, set, "set");
+cmdline_parse_token_string_t cmd_settunnel_tunnel =
+	TOKEN_STRING_INITIALIZER(struct cmd_set_tunnel_mode_result, tunnel, "tunnel");
+cmdline_parse_token_string_t cmd_settunnel_mode =
+	TOKEN_STRING_INITIALIZER(struct cmd_set_tunnel_mode_result, mode,
+		"vxlan|geneve|none");
 
 cmdline_parse_inst_t cmd_set_fwd_mode = {
 	.f = cmd_set_fwd_mode_parsed,
@@ -4759,6 +4785,18 @@ cmdline_parse_inst_t cmd_set_fwd_mode = {
 		(void *)&cmd_setfwd_set,
 		(void *)&cmd_setfwd_fwd,
 		(void *)&cmd_setfwd_mode,
+		NULL,
+	},
+};
+
+cmdline_parse_inst_t cmd_set_tunnel_mode = {
+	.f = cmd_set_tunnel_mode_parsed,
+	.data = NULL,
+	.help_str = "set tunnel vxlan|geneve|none", /* defined at init */
+	.tokens = {
+		(void *)&cmd_settunnel_set,
+		(void *)&cmd_settunnel_tunnel,
+		(void *)&cmd_settunnel_mode,
 		NULL,
 	},
 };
@@ -11458,6 +11496,7 @@ cmdline_parse_ctx_t main_ctx[] = {
 	(cmdline_parse_inst_t *)&cmd_set_allmulti_mode_all,
 	(cmdline_parse_inst_t *)&cmd_set_flush_rx,
 	(cmdline_parse_inst_t *)&cmd_set_link_check,
+	(cmdline_parse_inst_t *)&cmd_set_tunnel_mode,
 #ifdef RTE_NIC_BYPASS
 	(cmdline_parse_inst_t *)&cmd_set_bypass_mode,
 	(cmdline_parse_inst_t *)&cmd_set_bypass_event,

--- a/app/test-pmd/config.c
+++ b/app/test-pmd/config.c
@@ -1804,6 +1804,29 @@ set_pkt_forwarding_mode(const char *fwd_mode_name)
 }
 
 void
+set_tunnel_mode(const char *tunnel_mode_name)
+{
+	if (! strcmp(cur_fwd_eng->fwd_mode_name, "txonly")) {
+		if (! strcmp(tunnel_mode_name, "vxlan")) {
+			tx_vxlan = 1;
+			tx_geneve = 0;
+		} else if (! strcmp(tunnel_mode_name, "geneve")) {
+			tx_geneve = 1;
+			tx_vxlan = 0;
+		} else if (! strcmp(tunnel_mode_name, "none")) {
+			tx_vxlan = 0;
+			tx_geneve = 0;
+		} else {
+			printf("Unknown Tunnel mode\n");
+		}
+		return;
+	}
+
+	printf("Invalid %s packet forwarding mode\n", cur_fwd_eng->fwd_mode_name);
+	printf("Configure Tx only mode\n");
+}
+
+void
 set_verbose_level(uint16_t vb_level)
 {
 	printf("Change verbose level from %u to %u\n",

--- a/app/test-pmd/testpmd.c
+++ b/app/test-pmd/testpmd.c
@@ -332,6 +332,9 @@ static void check_all_ports_link_status(uint32_t port_mask);
  */
 static int all_ports_started(void);
 
+uint8_t tx_geneve = 0;
+uint8_t tx_vxlan = 0;
+
 /*
  * Find next enabled port
  */

--- a/app/test-pmd/testpmd.h
+++ b/app/test-pmd/testpmd.h
@@ -404,6 +404,9 @@ extern struct ether_addr peer_eth_addrs[RTE_MAX_ETHPORTS];
 extern uint32_t burst_tx_delay_time; /**< Burst tx delay time(us) for mac-retry. */
 extern uint32_t burst_tx_retry_num;  /**< Burst tx retry number for mac-retry. */
 
+extern uint8_t tx_vxlan;
+extern uint8_t tx_geneve;
+
 static inline unsigned int
 lcore_num(void)
 {
@@ -541,6 +544,7 @@ void set_nb_pkt_per_burst(uint16_t pkt_burst);
 char *list_pkt_forwarding_modes(void);
 char *list_pkt_forwarding_retry_modes(void);
 void set_pkt_forwarding_mode(const char *fwd_mode);
+void set_tunnel_mode(const char *tunnel_mode_name);
 void start_packet_forwarding(int with_tx_first);
 void stop_packet_forwarding(void);
 void dev_set_link_up(portid_t pid);


### PR DESCRIPTION
This code adds support to generate geneve and vxlan traffic.
This mode works in txonly forwarding mode.

To generate tunnel traffic, first set fwd mode to txonly.
set fwd txonly
Then set the desired tunnel mode.
set tunnel vxlan
Or
set tunnel geneve
Once tunnel mode is set, all the traffic will have the appropriate
tunnel header along with the inner/outer headers.

To disable any tunnel traffic,
set tunnel none

Signed-off-by: Ajit Khaparde <ajit.khaparde@broadcom.com>