### PR TITLE
app/testpmd: Add support to generate nvgre traffic

### DIFF
--- a/app/test-pmd/cmdline.c
+++ b/app/test-pmd/cmdline.c
@@ -265,7 +265,7 @@ static void cmd_help_long_parsed(void *parsed_result,
 			"set portlist (x[,y]*)\n"
 			"    Set the list of forwarding ports.\n\n"
 
-			"set tunnel (vxlan|geneve|none)\n"
+			"set tunnel (vxlan|geneve|nvgre|none)\n"
 			"    Set the Tunnel Mode.\n\n"
 
 #ifdef RTE_LIBRTE_IXGBE_PMD
@@ -4775,7 +4775,7 @@ cmdline_parse_token_string_t cmd_settunnel_tunnel =
 	TOKEN_STRING_INITIALIZER(struct cmd_set_tunnel_mode_result, tunnel, "tunnel");
 cmdline_parse_token_string_t cmd_settunnel_mode =
 	TOKEN_STRING_INITIALIZER(struct cmd_set_tunnel_mode_result, mode,
-		"vxlan|geneve|none");
+		"" /* defined at init */);
 
 cmdline_parse_inst_t cmd_set_fwd_mode = {
 	.f = cmd_set_fwd_mode_parsed,
@@ -4792,7 +4792,7 @@ cmdline_parse_inst_t cmd_set_fwd_mode = {
 cmdline_parse_inst_t cmd_set_tunnel_mode = {
 	.f = cmd_set_tunnel_mode_parsed,
 	.data = NULL,
-	.help_str = "set tunnel vxlan|geneve|none", /* defined at init */
+	.help_str = "set tunnel vxlan|geneve|nvgre|none", /* defined at init */
 	.tokens = {
 		(void *)&cmd_settunnel_set,
 		(void *)&cmd_settunnel_tunnel,

--- a/app/test-pmd/cmdline.c
+++ b/app/test-pmd/cmdline.c
@@ -10932,9 +10932,14 @@ cmd_set_vf_mac_anti_spoof_parsed(
 	struct cmd_vf_mac_anti_spoof_result *res = parsed_result;
 	int ret;
 	int is_on = (strcmp(res->on_off, "on") == 0) ? 1 : 0;
+	struct rte_eth_dev *dev = &rte_eth_devices[res->port_id];
 
-	ret = rte_pmd_ixgbe_set_vf_mac_anti_spoof(res->port_id, res->vf_id,
-			is_on);
+	if (strcmp(dev->driver->pci_drv.driver.name, "net_bnxt") == 0)
+		ret = rte_pmd_bnxt_set_vf_mac_anti_spoof(res->port_id,
+							res->vf_id, is_on);
+	else
+		ret = rte_pmd_ixgbe_set_vf_mac_anti_spoof(res->port_id,
+							res->vf_id, is_on);
 	switch (ret) {
 	case 0:
 		break;
@@ -11428,10 +11433,10 @@ cmd_set_vf_mac_addr_parsed(
 	int ret;
 	struct rte_eth_dev *dev = &rte_eth_devices[res->port_id];
 
-	if (strcmp(dev->driver->pci_drv.driver.name, "net_bnxt") == 0)
+	if (strcmp(dev->driver->pci_drv.driver.name, "net_bnxt") == 0) {
 		ret = rte_pmd_bnxt_set_vf_mac_addr(res->port_id, res->vf_id,
 			&res->mac_addr);
-	else
+	} else
 		ret = rte_pmd_ixgbe_set_vf_mac_addr(res->port_id, res->vf_id,
 			&res->mac_addr);
 	switch (ret) {

--- a/app/test-pmd/config.c
+++ b/app/test-pmd/config.c
@@ -1810,12 +1810,19 @@ set_tunnel_mode(const char *tunnel_mode_name)
 		if (! strcmp(tunnel_mode_name, "vxlan")) {
 			tx_vxlan = 1;
 			tx_geneve = 0;
+			tx_nvgre = 0;
 		} else if (! strcmp(tunnel_mode_name, "geneve")) {
 			tx_geneve = 1;
 			tx_vxlan = 0;
+			tx_nvgre = 0;
+		} else if (! strcmp(tunnel_mode_name, "nvgre")) {
+			tx_nvgre = 1;
+			tx_vxlan = 0;
+			tx_geneve = 0;
 		} else if (! strcmp(tunnel_mode_name, "none")) {
 			tx_vxlan = 0;
 			tx_geneve = 0;
+			tx_nvgre = 0;
 		} else {
 			printf("Unknown Tunnel mode\n");
 		}

--- a/app/test-pmd/testpmd.c
+++ b/app/test-pmd/testpmd.c
@@ -334,6 +334,7 @@ static int all_ports_started(void);
 
 uint8_t tx_geneve = 0;
 uint8_t tx_vxlan = 0;
+uint8_t tx_nvgre = 0;
 
 /*
  * Find next enabled port

--- a/app/test-pmd/testpmd.h
+++ b/app/test-pmd/testpmd.h
@@ -406,6 +406,7 @@ extern uint32_t burst_tx_retry_num;  /**< Burst tx retry number for mac-retry. *
 
 extern uint8_t tx_vxlan;
 extern uint8_t tx_geneve;
+extern uint8_t tx_nvgre;
 
 static inline unsigned int
 lcore_num(void)

--- a/drivers/net/bnxt/bnxt.h
+++ b/drivers/net/bnxt/bnxt.h
@@ -59,6 +59,7 @@ struct bnxt_child_vf_info {
 	uint16_t		max_tx_rate;
 	uint32_t		func_cfg_flags;
 	void			*req_buf;
+	uint8_t			mac_spoof_en;
 };
 
 struct bnxt_pf_info {

--- a/drivers/net/bnxt/bnxt_hwrm.c
+++ b/drivers/net/bnxt/bnxt_hwrm.c
@@ -2113,3 +2113,19 @@ int bnxt_hwrm_func_bw_cfg(struct bnxt *bp, uint16_t vf,
 
 	return rc;
 }
+
+int bnxt_hwrm_func_cfg_set_vf_mac_spoof(struct bnxt *bp, uint16_t vf,
+					uint32_t flags)
+{
+	struct hwrm_func_cfg_output *resp = bp->hwrm_cmd_resp_addr;
+	struct hwrm_func_cfg_input req = {0};
+	int rc;
+
+	HWRM_PREP(req, FUNC_CFG, -1, resp);
+	req.fid = rte_cpu_to_le_16(bp->pf.vf_info[vf].fid);
+	req.flags = rte_cpu_to_le_32(flags);
+	rc = bnxt_hwrm_send_message(bp, &req, sizeof(req));
+	HWRM_CHECK_RESULT;
+
+	return rc;
+}

--- a/drivers/net/bnxt/bnxt_hwrm.h
+++ b/drivers/net/bnxt/bnxt_hwrm.h
@@ -119,4 +119,6 @@ int bnxt_hwrm_tunnel_dst_port_alloc(struct bnxt *bp, uint16_t port,
 int bnxt_hwrm_tunnel_dst_port_free(struct bnxt *bp, uint16_t port,
 				uint8_t tunnel_type);
 void bnxt_free_tunnel_ports(struct bnxt *bp);
+int bnxt_hwrm_func_cfg_set_vf_mac_spoof(struct bnxt *bp, uint16_t vf,
+					uint32_t flags);
 #endif

--- a/drivers/net/bnxt/rte_pmd_bnxt.c
+++ b/drivers/net/bnxt/rte_pmd_bnxt.c
@@ -220,3 +220,54 @@ int bnxt_rcv_msg_from_vf(struct bnxt *bp, uint16_t vf_id, uint16_t type,
 	return _rte_callback_process(bp, &cb_param);
 }
 
+int rte_pmd_bnxt_set_vf_mac_anti_spoof(uint8_t port, uint16_t vf, uint8_t on)
+{
+	struct rte_eth_dev_info dev_info;
+	struct rte_eth_dev *dev;
+	uint32_t func_flags;
+	struct bnxt *bp;
+	int rc;
+
+	RTE_ETH_VALID_PORTID_OR_ERR_RET(port, -ENODEV);
+
+	if (on > 1)
+		return -EINVAL;
+
+	dev = &rte_eth_devices[port];
+	rte_eth_dev_info_get(port, &dev_info);
+	bp = (struct bnxt *)dev->data->dev_private;
+
+	if (!BNXT_PF(bp)) {
+		RTE_LOG(ERR, PMD, "Attempt to set mac spoof on non-PF port %d!\n",
+				port);
+		return -EINVAL;
+	}
+
+	if (vf >= dev_info.max_vfs)
+		return -EINVAL;
+
+	if (on > 1)	
+		return -EINVAL;
+
+	/* Prev setting same as new setting. */
+	if (on == bp->pf.vf_info[vf].mac_spoof_en)
+		return 0;
+
+	func_flags = bp->pf.vf_info[vf].func_cfg_flags;
+
+	if (on)
+		func_flags |= HWRM_FUNC_CFG_INPUT_FLAGS_SRC_MAC_ADDR_CHECK;
+	else
+		func_flags &= ~HWRM_FUNC_CFG_INPUT_FLAGS_SRC_MAC_ADDR_CHECK;
+
+	rc = bnxt_hwrm_func_cfg_set_vf_mac_spoof(bp, vf, func_flags);
+	if (!rc) {
+		bp->pf.vf_info[vf].func_cfg_flags = func_flags;
+		bp->pf.vf_info[vf].mac_spoof_en = 1;
+	} else {
+		bp->pf.vf_info[vf].mac_spoof_en = 0;
+	}
+
+	return rc;
+}
+

--- a/drivers/net/bnxt/rte_pmd_bnxt.h
+++ b/drivers/net/bnxt/rte_pmd_bnxt.h
@@ -113,4 +113,21 @@ struct rte_pmd_bnxt_mb_event_param {
 	void 	*msg;      /**< pointer to message */
 };
 
+/**
+ * Enable/Disable VF MAC anti spoof
+ *
+ * @param port
+ *    The port identifier of the Ethernet device.
+ * @param vf
+ *   VF id.
+ * @param on
+ *    1 - Enable VF MAC anti spoof.
+ *    0 - Disable VF MAC anti spoof.
+ *
+ * @return
+ *   - (0) if successful.
+ *   - (-ENODEV) if *port* invalid.
+ *   - (-EINVAL) if bad parameter.
+ */
+int rte_pmd_bnxt_set_vf_mac_anti_spoof(uint8_t port, uint16_t vf, uint8_t on);
 #endif /* _PMD_BNXT_H_ */


### PR DESCRIPTION
This adds support to generate nvgre traffic
As with vxlan and geneve tunnel modes, this mode also works when
the fwd mode is set to txonly.

To enable this mode:
set fwd txonly
set tunnel nvgre

To disable:
set tunnel none

Signed-off-by: Ajit Khaparde <ajit.khaparde@broadcom.com>