### PR TITLE
bnxt: Add support for vmdq pools in PF

### DIFF
--- a/drivers/net/bnxt/bnxt.h
+++ b/drivers/net/bnxt/bnxt.h
@@ -178,6 +178,8 @@ struct bnxt {
 	uint16_t		max_vnics;
 	uint16_t		max_stat_ctx;
 	uint16_t		vlan;
+	uint16_t		max_vmdq_pools;
+	uint16_t		vmdq_queue_num;
 	struct bnxt_pf_info		pf;
 	uint8_t			port_partition_type;
 	uint8_t			dev_stopped;

--- a/drivers/net/bnxt/bnxt_hwrm.c
+++ b/drivers/net/bnxt/bnxt_hwrm.c
@@ -1235,8 +1235,10 @@ int bnxt_alloc_all_hwrm_stat_ctxs(struct bnxt *bp)
 
 		rc = bnxt_hwrm_stat_ctx_alloc(bp, cpr, idx);
 
-		if (rc)
+		if (rc) {
+			RTE_LOG(ERR, PMD, "stat ctx alloc failed at %d\n", idx);
 			return rc;
+		}
 	}
 	return rc;
 }


### PR DESCRIPTION
Set max_mac_addrs based on the max_l2 contexts

Derive VMDQ pools supported based on the max_vnics, max_l2_ctxt and
max_rsscos_ctxt.

This also fixes a segfault seen when the vmdq app is loaded
caused because of insufficient stat contexts.

Set default pool bit in VNIC based on the vmdq_conf values if available.
Else use vnic0 as the default VNIC.

Signed-off-by: Ajit Khaparde <ajit.khaparde@broadcom.com>