### PR TITLE
16.11 vf

### DIFF
--- a/drivers/net/bnxt/bnxt.h
+++ b/drivers/net/bnxt/bnxt.h
@@ -58,6 +58,7 @@ struct bnxt_child_vf_info {
 	uint16_t		fid;
 	uint16_t		max_tx_rate;
 	uint32_t		func_cfg_flags;
+	uint32_t		l2_rx_mask;
 	uint16_t		dflt_vlan;
 	void			*req_buf;
 	uint8_t			mac_spoof_en;

--- a/drivers/net/bnxt/bnxt_ethdev.c
+++ b/drivers/net/bnxt/bnxt_ethdev.c
@@ -1158,9 +1158,9 @@ static int bnxt_set_vf_rx_mode_op(struct rte_eth_dev *dev, uint16_t vf,
 	}
 
 	if (rx_mask & ETH_VMDQ_ACCEPT_BROADCAST)
-		flag = BNXT_VNIC_INFO_BCAST;
+		flag |= BNXT_VNIC_INFO_BCAST;
 	if (rx_mask & ETH_VMDQ_ACCEPT_MULTICAST)
-		flag = BNXT_VNIC_INFO_ALLMULTI;
+		flag |= BNXT_VNIC_INFO_ALLMULTI;
 
 	if (on)
 		bp->pf.vf_info[vf].l2_rx_mask |= flag;

--- a/drivers/net/bnxt/bnxt_ethdev.c
+++ b/drivers/net/bnxt/bnxt_ethdev.c
@@ -1149,8 +1149,8 @@ static int bnxt_set_vf_rx_mode_op(struct rte_eth_dev *dev, uint16_t vf,
 
 	switch (rx_mask) {
 	case ETH_VMDQ_ACCEPT_UNTAG:
-		flag = BNXT_VNIC_INFO_UNTAGGED;
-		break;
+		RTE_LOG(ERR, PMD, "Currently cannot toggle this setting\n");
+		return -ENOTSUP;
 	case ETH_VMDQ_ACCEPT_BROADCAST:
 		flag = BNXT_VNIC_INFO_BCAST;
 		break;

--- a/drivers/net/bnxt/bnxt_ethdev.c
+++ b/drivers/net/bnxt/bnxt_ethdev.c
@@ -1175,7 +1175,10 @@ static int bnxt_set_vf_rx_mode_op(struct rte_eth_dev *dev, uint16_t vf,
 	else
 		bp->pf.vf_info[vf].l2_rx_mask &= ~flag;
 
-	rc = bnxt_hwrm_func_vf_vnic_set_rxmask(bp, vf);
+	rc = bnxt_hwrm_func_vf_vnic_query_and_config(bp, vf,
+					vf_vnic_set_rxmask_cb,
+					&bp->pf.vf_info[vf].l2_rx_mask,
+					bnxt_hwrm_cfa_l2_set_rx_mask);
 	if (rc)
 		RTE_LOG(ERR, PMD, "bnxt_hwrm_func_vf_vnic_set_rxmask failed\n");
 

--- a/drivers/net/bnxt/bnxt_hwrm.c
+++ b/drivers/net/bnxt/bnxt_hwrm.c
@@ -2099,7 +2099,31 @@ int bnxt_hwrm_set_vf_vlan(struct bnxt *bp, int vf)
 	return rc;
 }
 
-int bnxt_hwrm_func_vf_vnic_cfg_do(struct bnxt *bp, uint16_t vf, void (*vnic_cb)(struct bnxt_vnic_info *, void *), void *cbdata)
+int bnxt_hwrm_func_cfg_vf_set_flags(struct bnxt *bp, uint16_t vf)
+{
+	struct hwrm_func_cfg_output *resp = bp->hwrm_cmd_resp_addr;
+	struct hwrm_func_cfg_input req = {0};
+	int rc;
+
+	HWRM_PREP(req, FUNC_CFG, -1, resp);
+	req.fid = rte_cpu_to_le_16(bp->pf.vf_info[vf].fid);
+	req.flags = rte_cpu_to_le_32(bp->pf.vf_info[vf].func_cfg_flags);
+	rc = bnxt_hwrm_send_message(bp, &req, sizeof(req));
+	HWRM_CHECK_RESULT;
+
+	return rc;
+}
+
+void vf_vnic_set_rxmask_cb(struct bnxt_vnic_info *vnic, void *flagp)
+{
+	uint32_t *flag = flagp;
+
+	vnic->flags = *flag;
+}
+
+int bnxt_hwrm_func_vf_vnic_query_and_config(struct bnxt *bp, uint16_t vf,
+	void (*vnic_cb)(struct bnxt_vnic_info *, void *), void *cbdata,
+	int (*hwrm_do_cb)(struct bnxt *bp, struct bnxt_vnic_info *vnic))
 {
 	struct hwrm_func_vf_vnic_ids_query_input req = {0};
 	struct hwrm_func_vf_vnic_ids_query_output *resp = bp->hwrm_cmd_resp_addr;
@@ -2144,77 +2168,7 @@ int bnxt_hwrm_func_vf_vnic_cfg_do(struct bnxt *bp, uint16_t vf, void (*vnic_cb)(
 
 		vnic_cb(&vnic, cbdata);
 
-		rc = bnxt_hwrm_vnic_cfg(bp, &vnic);
-		if (rc)
-			break;
-	}
-
-	rte_free(vnic_ids);
-
-	return rc;
-}
-
-int bnxt_hwrm_func_cfg_vf_set_flags(struct bnxt *bp, uint16_t vf)
-{
-	struct hwrm_func_cfg_output *resp = bp->hwrm_cmd_resp_addr;
-	struct hwrm_func_cfg_input req = {0};
-	int rc;
-
-	HWRM_PREP(req, FUNC_CFG, -1, resp);
-	req.fid = rte_cpu_to_le_16(bp->pf.vf_info[vf].fid);
-	req.flags = rte_cpu_to_le_32(bp->pf.vf_info[vf].func_cfg_flags);
-	rc = bnxt_hwrm_send_message(bp, &req, sizeof(req));
-	HWRM_CHECK_RESULT;
-
-	return rc;
-}
-
-int bnxt_hwrm_func_vf_vnic_set_rxmask(struct bnxt *bp, uint16_t vf)
-{
-	struct hwrm_func_vf_vnic_ids_query_input req = {0};
-	struct hwrm_func_vf_vnic_ids_query_output *resp = bp->hwrm_cmd_resp_addr;
-	struct bnxt_vnic_info vnic;
-	int rc;
-	uint32_t i, num_vnic_ids;
-	uint16_t *vnic_ids;
-	size_t vnic_id_sz;
-
-	/* First query all VNIC ids */
-
-	vnic_id_sz = bp->pf.total_vnics * sizeof(*vnic_ids);
-	vnic_ids = rte_malloc("bnxt_hwrm_vf_vnic_ids_query", vnic_id_sz,
-			RTE_CACHE_LINE_SIZE);
-	if (vnic_ids == NULL) {
-		rc = -ENOMEM;
-		return rc;
-	}
-	for (i = 0; i< vnic_id_sz; i+=rte_eal_get_physmem_size()) {
-		rte_mem_lock_page(((char *)vnic_ids) + i);
-	}
-
-	HWRM_PREP(req, FUNC_VF_VNIC_IDS_QUERY, -1, resp_vf_vnic_ids);
-
-	req.vf_id = rte_cpu_to_le_16(bp->pf.first_vf_id + vf);
-	req.max_vnic_id_cnt = rte_cpu_to_le_32(bp->pf.total_vnics);
-	req.vnic_id_tbl_addr = rte_mem_virt2phy(vnic_ids);
-
-	rc = bnxt_hwrm_send_message(bp, &req, sizeof(req));
-	HWRM_CHECK_RESULT;
-
-	num_vnic_ids = rte_le_to_cpu_32(resp->vnic_id_cnt);
-
-	/* Retrieve VNIC, update bd_stall then update */
-
-	for (i = 0; i < num_vnic_ids; i++) {
-		memset(&vnic, 0, sizeof(struct bnxt_vnic_info));
-		vnic.fw_vnic_id = rte_le_to_cpu_16(vnic_ids[i]);
-		rc = bnxt_hwrm_vnic_qcfg(bp, &vnic, bp->pf.first_vf_id + vf);
-		if (rc)
-			break;
-
-		vnic.flags = bp->pf.vf_info[vf].l2_rx_mask;
-
-		rc = bnxt_hwrm_cfa_l2_set_rx_mask(bp, &vnic);
+		rc = hwrm_do_cb(bp, &vnic);
 		if (rc)
 			break;
 	}

--- a/drivers/net/bnxt/bnxt_hwrm.h
+++ b/drivers/net/bnxt/bnxt_hwrm.h
@@ -119,10 +119,10 @@ int bnxt_hwrm_tunnel_dst_port_alloc(struct bnxt *bp, uint16_t port,
 int bnxt_hwrm_tunnel_dst_port_free(struct bnxt *bp, uint16_t port,
 				uint8_t tunnel_type);
 void bnxt_free_tunnel_ports(struct bnxt *bp);
-int bnxt_hwrm_func_vf_vnic_cfg_do(struct bnxt *bp, uint16_t vf,
-				  void (*vnic_cb)(struct bnxt_vnic_info *, void *),
-				  void *cbdata);
 int bnxt_hwrm_func_cfg_vf_set_flags(struct bnxt *bp, uint16_t vf);
-int bnxt_hwrm_func_vf_vnic_set_rxmask(struct bnxt *bp, uint16_t vf);
+void vf_vnic_set_rxmask_cb(struct bnxt_vnic_info *vnic, void *flagp);
+int bnxt_hwrm_func_vf_vnic_query_and_config(struct bnxt *bp, uint16_t vf,
+	void (*vnic_cb)(struct bnxt_vnic_info *, void *), void *cbdata,
+	int (*hwrm_do_cb)(struct bnxt *bp, struct bnxt_vnic_info *vnic));
 
 #endif

--- a/drivers/net/bnxt/bnxt_hwrm.h
+++ b/drivers/net/bnxt/bnxt_hwrm.h
@@ -123,5 +123,6 @@ int bnxt_hwrm_func_vf_vnic_cfg_do(struct bnxt *bp, uint16_t vf,
 				  void (*vnic_cb)(struct bnxt_vnic_info *, void *),
 				  void *cbdata);
 int bnxt_hwrm_func_cfg_vf_set_flags(struct bnxt *bp, uint16_t vf);
+int bnxt_hwrm_func_vf_vnic_set_rxmask(struct bnxt *bp, uint16_t vf);
 
 #endif

--- a/drivers/net/bnxt/bnxt_hwrm.h
+++ b/drivers/net/bnxt/bnxt_hwrm.h
@@ -123,6 +123,6 @@ int bnxt_hwrm_func_cfg_vf_set_flags(struct bnxt *bp, uint16_t vf);
 void vf_vnic_set_rxmask_cb(struct bnxt_vnic_info *vnic, void *flagp);
 int bnxt_hwrm_func_vf_vnic_query_and_config(struct bnxt *bp, uint16_t vf,
 	void (*vnic_cb)(struct bnxt_vnic_info *, void *), void *cbdata,
-	int (*hwrm_do_cb)(struct bnxt *bp, struct bnxt_vnic_info *vnic));
+	int (*hwrm_cb)(struct bnxt *bp, struct bnxt_vnic_info *vnic));
 
 #endif

--- a/drivers/net/bnxt/bnxt_rxq.c
+++ b/drivers/net/bnxt/bnxt_rxq.c
@@ -76,6 +76,7 @@ int bnxt_mq_rx_configure(struct bnxt *bp)
 			rc = -ENOMEM;
 			goto err_out;
 		}
+		vnic->flags |= BNXT_VNIC_INFO_BCAST;
 		STAILQ_INSERT_TAIL(&bp->ff_pool[0], vnic, next);
 		bp->nr_vnics++;
 
@@ -140,6 +141,7 @@ int bnxt_mq_rx_configure(struct bnxt *bp)
 				rc = -ENOMEM;
 				goto err_out;
 			}
+			vnic->flags |= BNXT_VNIC_INFO_BCAST;
 			STAILQ_INSERT_TAIL(&bp->ff_pool[i], vnic, next);
 			bp->nr_vnics++;
 
@@ -180,6 +182,7 @@ int bnxt_mq_rx_configure(struct bnxt *bp)
 		rc = -ENOMEM;
 		goto err_out;
 	}
+	vnic->flags |= BNXT_VNIC_INFO_BCAST;
 	/* Partition the rx queues for the single pool */
 	for (i = 0; i < bp->rx_cp_nr_rings; i++) {
 		rxq = bp->eth_dev->data->rx_queues[i];

--- a/drivers/net/bnxt/bnxt_vnic.h
+++ b/drivers/net/bnxt/bnxt_vnic.h
@@ -61,6 +61,11 @@ struct bnxt_vnic_info {
 	uint32_t	flags;
 #define BNXT_VNIC_INFO_PROMISC			(1 << 0)
 #define BNXT_VNIC_INFO_ALLMULTI			(1 << 1)
+#define BNXT_VNIC_INFO_BCAST			(1 << 2)
+#define BNXT_VNIC_INFO_UCAST			(1 << 3)
+#define BNXT_VNIC_INFO_MCAST			(1 << 4)
+#define BNXT_VNIC_INFO_TAGGED			(1 << 5)
+#define BNXT_VNIC_INFO_UNTAGGED			(1 << 6)
 
 	bool		vlan_strip;
 	bool		func_default;

--- a/drivers/net/bnxt/rte_pmd_bnxt.c
+++ b/drivers/net/bnxt/rte_pmd_bnxt.c
@@ -119,7 +119,9 @@ int rte_pmd_bnxt_set_all_queues_drop_en(uint8_t port, uint8_t on)
 
 	/* Stall all active VFs */
 	for (i = 0; i < bp->pf.active_vfs; i++) {
-		rc = bnxt_hwrm_func_vf_vnic_cfg_do(bp, i, rte_pmd_bnxt_set_all_queues_drop_en_cb, &on);
+		rc = bnxt_hwrm_func_vf_vnic_query_and_config(bp, i,
+				rte_pmd_bnxt_set_all_queues_drop_en_cb, &on,
+				bnxt_hwrm_vnic_cfg);
 		if (rc) {
 			RTE_LOG(ERR, PMD, "Failed to update VF VNIC %d.\n", i);
 			break;
@@ -256,7 +258,9 @@ rte_pmd_bnxt_set_vf_vlan_stripq(uint8_t port, uint16_t vf, uint8_t on)
 		return -ENOTSUP;
 	}
 
-	rc = bnxt_hwrm_func_vf_vnic_cfg_do(bp, vf, rte_pmd_bnxt_set_vf_vlan_stripq_cb, &on);
+	rc = bnxt_hwrm_func_vf_vnic_query_and_config(bp, vf,
+				rte_pmd_bnxt_set_vf_vlan_stripq_cb, &on,
+				bnxt_hwrm_vnic_cfg);
 	if (rc) {
 		RTE_LOG(ERR, PMD, "Failed to update VF VNIC %d.\n", vf);
 	}


### PR DESCRIPTION
Add support for rte_eth_dev_set_vf_rxmode dev_op.

ETH_VMDQ_ACCEPT_HASH_MC - Not supported. We don't have a way for passing Multicast table for VF.

ETH_VMDQ_ACCEPT_HASH_UC - Since we add a default Unicast MAC address, only packets matching that MAC address will be received. So we do not disable this feature.

ETH_VMDQ_ACCEPT_UNTAG - Not supported right now.

Otherwise rest of the modes are supported.