### PR TITLE
Check the return value of rte_mem_virt2phy()

### DIFF
--- a/drivers/net/bnxt/bnxt_ring.c
+++ b/drivers/net/bnxt/bnxt_ring.c
@@ -149,6 +149,10 @@ int bnxt_alloc_rings(struct bnxt *bp, uint16_t qidx,
 	if ((phys_addr_t)mz->addr == mz_phys_addr) {
 		RTE_LOG(WARNING, PMD, "Memzone physical address same as virtual.  Using rte_mem_virt2phy()\n");
 		mz_phys_addr = rte_mem_virt2phy(mz->addr);
+		if (mz_phys_addr == 0) {
+			RTE_LOG(ERR, PMD, "unable to map ring address to physical memory\n");
+			return -ENOMEM;
+		}
 	}
 
 	if (tx_ring_info) {

--- a/drivers/net/bnxt/bnxt_vnic.c
+++ b/drivers/net/bnxt/bnxt_vnic.c
@@ -193,6 +193,10 @@ int bnxt_alloc_vnic_attributes(struct bnxt *bp)
 	if ((phys_addr_t)mz->addr == mz_phys_addr) {
 		RTE_LOG(WARNING, PMD, "Memzone physical address same as virtual.  Using rte_mem_virt2phy()\n");
 		mz_phys_addr = rte_mem_virt2phy(mz->addr);
+		if (mz_phys_addr == 0) {
+			RTE_LOG(ERR, PMD, "unable to map vnic address to physical memory\n");
+			return -ENOMEM;
+		}
 	}
 
 	for (i = 0; i < max_vnics; i++) {


### PR DESCRIPTION
Previously, success was assumed.  Verify the function returns an
address and return an error and log a message if not.