### PR TITLE
fix to set vf mac

### DIFF
--- a/drivers/net/bnxt/bnxt.h
+++ b/drivers/net/bnxt/bnxt.h
@@ -63,6 +63,8 @@ struct bnxt_child_vf_info {
 	void			*req_buf;
 	uint8_t			mac_spoof_en;
 	uint8_t			vlan_spoof_en;
+	uint8_t			mac_count;
+	struct ether_addr	mac_addrs[ETH_NUM_RECEIVE_MAC_ADDR];
 };
 
 struct bnxt_pf_info {

--- a/drivers/net/bnxt/bnxt_ethdev.c
+++ b/drivers/net/bnxt/bnxt_ethdev.c
@@ -36,6 +36,7 @@
 
 #include <rte_dev.h>
 #include <rte_ethdev.h>
+//#include <rte_ether.h>
 #include <rte_malloc.h>
 #include <rte_cycles.h>
 
@@ -600,6 +601,16 @@ static void bnxt_mac_addr_add_op(struct rte_eth_dev *eth_dev,
 
 	if (!vnic) {
 		RTE_LOG(ERR, PMD, "VNIC not found for pool %d!\n", pool);
+		RTE_LOG(ERR, PMD, "VNIC index %d, for pool %d!\n", index, pool);
+		if (bp->pdev->max_vfs && (pool < bp->pdev->max_vfs)) {
+			uint16_t cnt = bp->pf.vf_info[pool].mac_count;
+
+			bnxt_hwrm_func_vf_mac(bp, pool, (uint8_t *)mac_addr);
+			/* Update address in PF.vf_info */
+			ether_addr_copy(mac_addr,
+					&bp->pf.vf_info[pool].mac_addrs[cnt]);
+			bp->pf.vf_info[pool].mac_count++;
+		}
 		return;
 	}
 	/* Attach requested MAC address to the new l2_filter */


### PR DESCRIPTION
mac_addr_add dev_op uses "pools" to indicate VF number.
But the bnxt_mac_addr_add_op doesn't use it correctly.
This patch tries to fix that.

Signed-off-by: Ajit Khaparde <ajit.khaparde@broadcom.com>