### PR TITLE
bnxt_hwrm_set_filter() take a dst_id instead of a vnic

### DIFF
--- a/drivers/net/bnxt/bnxt_ethdev.c
+++ b/drivers/net/bnxt/bnxt_ethdev.c
@@ -618,7 +618,7 @@ static void bnxt_mac_addr_add_op(struct rte_eth_dev *eth_dev,
 	STAILQ_INSERT_TAIL(&vnic->filter, filter, next);
 	filter->mac_index = index;
 	memcpy(filter->l2_addr, mac_addr, ETHER_ADDR_LEN);
-	bnxt_hwrm_set_filter(bp, vnic, filter);
+	bnxt_hwrm_set_filter(bp, vnic->fw_vnic_id, filter);
 }
 
 int bnxt_link_update_op(struct rte_eth_dev *eth_dev, int wait_to_complete)

--- a/drivers/net/bnxt/bnxt_filter.h
+++ b/drivers/net/bnxt/bnxt_filter.h
@@ -64,6 +64,8 @@ struct bnxt_filter_info {
 	uint32_t		vni;
 	uint8_t			pri_hint;
 	uint64_t		l2_filter_id_hint;
+	uint32_t		src_id;
+	uint8_t			src_type;
 };
 
 struct bnxt_filter_info *bnxt_alloc_filter(struct bnxt *bp);

--- a/drivers/net/bnxt/bnxt_hwrm.c
+++ b/drivers/net/bnxt/bnxt_hwrm.c
@@ -304,7 +304,7 @@ int bnxt_hwrm_set_filter(struct bnxt *bp,
 	if (enables & HWRM_CFA_L2_FILTER_ALLOC_INPUT_ENABLES_SRC_ID)
 		req.src_id = rte_cpu_to_le_32(filter->src_id);
 	if (enables & HWRM_CFA_L2_FILTER_ALLOC_INPUT_ENABLES_SRC_TYPE)
-		req.src_type = rte_cpu_to_le_32(filter->src_type);
+		req.src_type = filter->src_type;
 
 	req.enables = rte_cpu_to_le_32(enables);
 

--- a/drivers/net/bnxt/bnxt_hwrm.c
+++ b/drivers/net/bnxt/bnxt_hwrm.c
@@ -268,7 +268,7 @@ int bnxt_hwrm_clear_filter(struct bnxt *bp,
 }
 
 int bnxt_hwrm_set_filter(struct bnxt *bp,
-			 struct bnxt_vnic_info *vnic,
+			 uint16_t dst_id,
 			 struct bnxt_filter_info *filter)
 {
 	int rc = 0;
@@ -285,7 +285,7 @@ int bnxt_hwrm_set_filter(struct bnxt *bp,
 
 	enables = filter->enables |
 	      HWRM_CFA_L2_FILTER_ALLOC_INPUT_ENABLES_DST_ID;
-	req.dst_id = rte_cpu_to_le_16(vnic->fw_vnic_id);
+	req.dst_id = rte_cpu_to_le_16(dst_id);
 
 	if (enables &
 	    HWRM_CFA_L2_FILTER_ALLOC_INPUT_ENABLES_L2_ADDR)
@@ -301,6 +301,10 @@ int bnxt_hwrm_set_filter(struct bnxt *bp,
 	if (enables &
 	    HWRM_CFA_L2_FILTER_ALLOC_INPUT_ENABLES_L2_OVLAN_MASK)
 		req.l2_ovlan_mask = filter->l2_ovlan_mask;
+	if (enables & HWRM_CFA_L2_FILTER_ALLOC_INPUT_ENABLES_SRC_ID)
+		req.src_id = rte_cpu_to_le_32(filter->src_id);
+	if (enables & HWRM_CFA_L2_FILTER_ALLOC_INPUT_ENABLES_SRC_TYPE)
+		req.src_type = rte_cpu_to_le_32(filter->src_type);
 
 	req.enables = rte_cpu_to_le_32(enables);
 
@@ -1600,7 +1604,7 @@ int bnxt_set_hwrm_vnic_filters(struct bnxt *bp, struct bnxt_vnic_info *vnic)
 			if (BNXT_VF(bp) || bp->pf.max_vfs)
 				continue;
 		}
-		rc = bnxt_hwrm_set_filter(bp, vnic, filter);
+		rc = bnxt_hwrm_set_filter(bp, vnic->fw_vnic_id, filter);
 		if (rc)
 			break;
 	}
@@ -2418,6 +2422,40 @@ int bnxt_vf_default_vnic_count(struct bnxt *bp, uint16_t vf)
 	return count;
 }
 
+static int bnxt_hwrm_func_vf_vnic_query(struct bnxt *bp, uint16_t vf,
+					uint16_t *vnic_ids)
+{
+	struct hwrm_func_vf_vnic_ids_query_input req = {0};
+	struct hwrm_func_vf_vnic_ids_query_output *resp =
+						bp->hwrm_cmd_resp_addr;
+	int rc;
+
+	/* First query all VNIC ids */
+	HWRM_PREP(req, FUNC_VF_VNIC_IDS_QUERY, -1, resp_vf_vnic_ids);
+
+	req.vf_id = rte_cpu_to_le_16(bp->pf.first_vf_id + vf);
+	req.max_vnic_id_cnt = rte_cpu_to_le_32(bp->pf.total_vnics);
+	req.vnic_id_tbl_addr = rte_cpu_to_le_64(rte_mem_virt2phy(vnic_ids));
+
+	if (req.vnic_id_tbl_addr == 0) {
+		RTE_LOG(ERR, PMD,
+		"unable to map VNIC ID table address to physical memory\n");
+		//rte_free(vnic_ids);
+		return -ENOMEM;
+	}
+	rc = bnxt_hwrm_send_message(bp, &req, sizeof(req));
+	if (rc) {
+		RTE_LOG(ERR, PMD, "hwrm_func_vf_vnic_query failed rc:%d\n", rc);
+		return -1;
+	} else if (resp->error_code) {
+		rc = rte_le_to_cpu_16(resp->error_code);
+		RTE_LOG(ERR, PMD, "hwrm_func_vf_vnic_query error %d\n", rc);
+		return -1;
+	}
+
+	return rte_le_to_cpu_32(resp->vnic_id_cnt);
+}
+
 /*
  * This function queries the VNIC IDs  for a specified VF. It then calls
  * the vnic_cb to update the necessary field in vnic_info with cbdata.
@@ -2427,17 +2465,14 @@ int bnxt_hwrm_func_vf_vnic_query_and_config(struct bnxt *bp, uint16_t vf,
 	void (*vnic_cb)(struct bnxt_vnic_info *, void *), void *cbdata,
 	int (*hwrm_cb)(struct bnxt *bp, struct bnxt_vnic_info *vnic))
 {
-	struct hwrm_func_vf_vnic_ids_query_input req = {0};
-	struct hwrm_func_vf_vnic_ids_query_output *resp = bp->hwrm_cmd_resp_addr;
 	struct bnxt_vnic_info vnic;
-	int rc;
-	uint32_t i, num_vnic_ids;
+	int rc = 0;
+	int i, num_vnic_ids;
 	uint16_t *vnic_ids;
 	size_t vnic_id_sz;
 	size_t sz;
 
 	/* First query all VNIC ids */
-
 	vnic_id_sz = bp->pf.total_vnics * sizeof(*vnic_ids);
 	vnic_ids = rte_malloc("bnxt_hwrm_vf_vnic_ids_query", vnic_id_sz,
 			RTE_CACHE_LINE_SIZE);
@@ -2449,21 +2484,10 @@ int bnxt_hwrm_func_vf_vnic_query_and_config(struct bnxt *bp, uint16_t vf,
 		rte_mem_lock_page(((char *)vnic_ids) + sz);
 	}
 
-	HWRM_PREP(req, FUNC_VF_VNIC_IDS_QUERY, -1, resp_vf_vnic_ids);
+	num_vnic_ids = bnxt_hwrm_func_vf_vnic_query(bp, vf, vnic_ids);
 
-	req.vf_id = rte_cpu_to_le_16(bp->pf.first_vf_id + vf);
-	req.max_vnic_id_cnt = rte_cpu_to_le_32(bp->pf.total_vnics);
-	req.vnic_id_tbl_addr = rte_cpu_to_le_64(rte_mem_virt2phy(vnic_ids));
-
-	if (req.vnic_id_tbl_addr == 0) {
-		RTE_LOG(ERR, PMD, "unable to map VNIC ID table address to physical memory\n");
-		rte_free(vnic_ids);
-		return -ENOMEM;
-	}
-	rc = bnxt_hwrm_send_message(bp, &req, sizeof(req));
-	HWRM_CHECK_RESULT;
-
-	num_vnic_ids = rte_le_to_cpu_32(resp->vnic_id_cnt);
+	if (num_vnic_ids < 0)
+		return num_vnic_ids;
 
 	/* Retrieve VNIC, update bd_stall then update */
 
@@ -2473,6 +2497,8 @@ int bnxt_hwrm_func_vf_vnic_query_and_config(struct bnxt *bp, uint16_t vf,
 		rc = bnxt_hwrm_vnic_qcfg(bp, &vnic, bp->pf.first_vf_id + vf);
 		if (rc)
 			break;
+		if (vnic.mru == 4)	// Unallocated
+			continue;
 
 		vnic_cb(&vnic, cbdata);
 
@@ -2502,40 +2528,6 @@ int bnxt_hwrm_func_cfg_vf_set_vlan_anti_spoof(struct bnxt *bp, uint16_t vf)
 	HWRM_CHECK_RESULT;
 
 	return rc;
-}
-
-int bnxt_hwrm_func_vf_vnic_query(struct bnxt *bp, uint16_t vf,
-					uint16_t *vnic_ids)
-{
-	struct hwrm_func_vf_vnic_ids_query_input req = {0};
-	struct hwrm_func_vf_vnic_ids_query_output *resp =
-						bp->hwrm_cmd_resp_addr;
-	int rc;
-
-	/* First query all VNIC ids */
-	HWRM_PREP(req, FUNC_VF_VNIC_IDS_QUERY, -1, resp_vf_vnic_ids);
-
-	req.vf_id = rte_cpu_to_le_16(bp->pf.first_vf_id + vf);
-	req.max_vnic_id_cnt = rte_cpu_to_le_32(bp->pf.total_vnics);
-	req.vnic_id_tbl_addr = rte_cpu_to_le_64(rte_mem_virt2phy(vnic_ids));
-
-	if (req.vnic_id_tbl_addr == 0) {
-		RTE_LOG(ERR, PMD,
-		"unable to map VNIC ID table address to physical memory\n");
-		//rte_free(vnic_ids);
-		return -ENOMEM;
-	}
-	rc = bnxt_hwrm_send_message(bp, &req, sizeof(req));
-	if (rc) {
-		RTE_LOG(ERR, PMD, "hwrm_func_qcfg failed rc:%d\n", rc);
-		return -1;
-	} else if (resp->error_code) {
-		rc = rte_le_to_cpu_16(resp->error_code);
-		RTE_LOG(ERR, PMD, "hwrm_func_qcfg error %d\n", rc);
-		return -1;
-	}
-
-	return rte_le_to_cpu_32(resp->vnic_id_cnt);
 }
 
 int bnxt_hwrm_func_qcfg_vf_dflt_vnic_id(struct bnxt *bp, int vf)

--- a/drivers/net/bnxt/bnxt_hwrm.h
+++ b/drivers/net/bnxt/bnxt_hwrm.h
@@ -49,7 +49,7 @@ int bnxt_hwrm_cfa_l2_set_rx_mask(struct bnxt *bp, struct bnxt_vnic_info *vnic);
 int bnxt_hwrm_clear_filter(struct bnxt *bp,
 			   struct bnxt_filter_info *filter);
 int bnxt_hwrm_set_filter(struct bnxt *bp,
-			 struct bnxt_vnic_info *vnic,
+			 uint16_t dst_id,
 			 struct bnxt_filter_info *filter);
 
 int bnxt_hwrm_exec_fwd_resp(struct bnxt *bp, uint16_t target_id,
@@ -132,8 +132,6 @@ int bnxt_hwrm_func_vf_vnic_query_and_config(struct bnxt *bp, uint16_t vf,
 	void (*vnic_cb)(struct bnxt_vnic_info *, void *), void *cbdata,
 	int (*hwrm_cb)(struct bnxt *bp, struct bnxt_vnic_info *vnic));
 int bnxt_hwrm_func_cfg_vf_set_vlan_anti_spoof(struct bnxt *bp, uint16_t vf);
-int bnxt_hwrm_func_vf_vnic_query(struct bnxt *bp, uint16_t vf,
-					uint16_t *vnic_ids);
 int bnxt_hwrm_func_qcfg_vf_dflt_vnic_id(struct bnxt *bp, int vf);
 
 #endif

--- a/drivers/net/bnxt/rte_pmd_bnxt.c
+++ b/drivers/net/bnxt/rte_pmd_bnxt.c
@@ -503,7 +503,8 @@ int rte_pmd_bnxt_mac_addr_add(uint8_t port, struct ether_addr *addr,
 			HWRM_CFA_L2_FILTER_ALLOC_INPUT_ENABLES_L2_ADDR_MASK;
 	memcpy(filter.l2_addr, addr, ETHER_ADDR_LEN);
 	memset(filter.l2_addr_mask, 0xff, ETHER_ADDR_LEN);
-	rc = bnxt_hwrm_set_filter(bp, &vnic, &filter);
+	rc = bnxt_hwrm_set_filter(bp, vnic.fw_vnic_id, &filter);
+
 exit:
 	return rc;
 }


### PR DESCRIPTION
Support source type/id in filters
Only call FUNC_VF_VNIC_IDS_QUERY from bnxt_hwrm_func_vf_vnic_query()
Make bnxt_hwrm_func_vf_vnic_query() static