### PR TITLE
Keep a list of MAC filters installed per VF, and re-use them instead

### DIFF
--- a/drivers/net/bnxt/bnxt.h
+++ b/drivers/net/bnxt/bnxt.h
@@ -64,6 +64,7 @@ struct bnxt_child_vf_info {
 	uint8_t			mac_spoof_en;
 	uint8_t			vlan_spoof_en;
 	bool			random_mac;
+	STAILQ_HEAD(, bnxt_filter_info)	filter;
 };
 
 struct bnxt_pf_info {

--- a/drivers/net/bnxt/bnxt_filter.c
+++ b/drivers/net/bnxt/bnxt_filter.c
@@ -68,6 +68,22 @@ struct bnxt_filter_info *bnxt_alloc_filter(struct bnxt *bp)
 	return filter;
 }
 
+struct bnxt_filter_info *bnxt_alloc_vf_filter(struct bnxt *bp, uint16_t vf)
+{
+	struct bnxt_filter_info *filter;
+
+	filter = rte_zmalloc("bnxt_vf_filter_info", sizeof(*filter), 0);
+	if (!filter) {
+		RTE_LOG(ERR, PMD, "Failed to alloc memory for VF %hu filters\n",
+			vf);
+		return NULL;
+	}
+
+	filter->fw_l2_filter_id = UINT64_MAX;
+	STAILQ_INSERT_TAIL(&bp->pf.vf_info[vf].filter, filter, next);
+	return filter;
+}
+
 void bnxt_init_filters(struct bnxt *bp)
 {
 	struct bnxt_filter_info *filter;
@@ -100,6 +116,12 @@ void bnxt_free_all_filters(struct bnxt *bp)
 				filter = temp_filter;
 			}
 			STAILQ_INIT(&vnic->filter);
+		}
+	}
+
+	for (i=0; i<bp->pf.max_vfs; i++) {
+		STAILQ_FOREACH(filter, &bp->pf.vf_info[i].filter, next) {
+			bnxt_hwrm_clear_filter(bp, filter);
 		}
 	}
 }

--- a/drivers/net/bnxt/bnxt_filter.h
+++ b/drivers/net/bnxt/bnxt_filter.h
@@ -69,6 +69,7 @@ struct bnxt_filter_info {
 };
 
 struct bnxt_filter_info *bnxt_alloc_filter(struct bnxt *bp);
+struct bnxt_filter_info *bnxt_alloc_vf_filter(struct bnxt *bp, uint16_t vf);
 void bnxt_init_filters(struct bnxt *bp);
 void bnxt_free_all_filters(struct bnxt *bp);
 void bnxt_free_filter_mem(struct bnxt *bp);

--- a/drivers/net/bnxt/bnxt_hwrm.c
+++ b/drivers/net/bnxt/bnxt_hwrm.c
@@ -344,8 +344,10 @@ int bnxt_hwrm_func_qcaps(struct bnxt *bp)
 			bp->pf.vf_info = rte_malloc("bnxt_vf_info",
 			    sizeof(bp->pf.vf_info[0]) * new_max_vfs, 0);
 			bp->pf.max_vfs = new_max_vfs;
-			for (i=0; i<new_max_vfs; i++)
+			for (i=0; i<new_max_vfs; i++) {
 				bp->pf.vf_info[i].fid = bp->pf.first_vf_id + i;
+				STAILQ_INIT(&bp->pf.vf_info[i].filter);
+			}
 		}
 	}
 

--- a/drivers/net/bnxt/rte_pmd_bnxt.c
+++ b/drivers/net/bnxt/rte_pmd_bnxt.c
@@ -108,8 +108,6 @@ int rte_pmd_bnxt_set_all_queues_drop_en(uint8_t port, uint8_t on)
 	if (bp->vnic_info == NULL)
 		return -ENODEV;
 
-	RTE_LOG(ERR, PMD, "rte_pmd_bnxt_set_all_queues_drop_en() non-functional\n");
-	return -1;
 	/* Stall PF */
 	for (i = 0; i < bp->nr_vnics; i++) {
 		bp->vnic_info[i].bd_stall = !on;
@@ -309,8 +307,6 @@ rte_pmd_bnxt_set_vf_vlan_stripq(uint8_t port, uint16_t vf, uint8_t on)
 		return -ENOTSUP;
 	}
 
-	RTE_LOG(ERR, PMD, "rte_pmd_bnxt_set_vf_vlan_stripq() non-functional\n");
-	return -1;
 	rc = bnxt_hwrm_func_vf_vnic_query_and_config(bp, vf,
 				rte_pmd_bnxt_set_vf_vlan_stripq_cb, &on,
 				bnxt_hwrm_vnic_cfg);
@@ -461,7 +457,7 @@ int rte_pmd_bnxt_mac_addr_add(uint8_t port, struct ether_addr *addr,
 	struct rte_eth_dev *dev;
 	struct rte_eth_dev_info dev_info;
 	struct bnxt *bp;
-	struct bnxt_filter_info filter;
+	struct bnxt_filter_info *filter;
 	struct bnxt_vnic_info vnic;
 	int rc;
 
@@ -482,7 +478,7 @@ int rte_pmd_bnxt_mac_addr_add(uint8_t port, struct ether_addr *addr,
 	/* If the VF currently uses a random MAC, update default to this one */
 	if (bp->pf.vf_info[vf_id].random_mac) {
 		if (rte_pmd_bnxt_get_vf_rx_status(port, vf_id) <= 0) {
-			bnxt_hwrm_func_vf_mac(bp, vf_id, (uint8_t *)addr);
+			rc = bnxt_hwrm_func_vf_mac(bp, vf_id, (uint8_t *)addr);
 		}
 	}
 
@@ -497,13 +493,29 @@ int rte_pmd_bnxt_mac_addr_add(uint8_t port, struct ether_addr *addr,
 	if (rc < 0)
 		goto exit;
 
-	filter.fw_l2_filter_id = UINT64_MAX;
-	filter.flags = HWRM_CFA_L2_FILTER_ALLOC_INPUT_FLAGS_PATH_RX;
-	filter.enables = HWRM_CFA_L2_FILTER_ALLOC_INPUT_ENABLES_L2_ADDR |
+	STAILQ_FOREACH(filter, &bp->pf.vf_info[vf_id].filter, next) {
+		if (filter->flags == HWRM_CFA_L2_FILTER_ALLOC_INPUT_FLAGS_PATH_RX
+		    && filter->enables == (HWRM_CFA_L2_FILTER_ALLOC_INPUT_ENABLES_L2_ADDR
+		        | HWRM_CFA_L2_FILTER_ALLOC_INPUT_ENABLES_L2_ADDR_MASK)
+		    && memcmp(addr, filter->l2_addr, ETHER_ADDR_LEN) == 0) {
+RTE_LOG(ERR, PMD, "Re-using filter...\n");
+			bnxt_hwrm_clear_filter(bp, filter);
+			break;
+		}
+	}
+
+	if (filter == NULL) {
+RTE_LOG(ERR, PMD, "New filter\n");
+		filter = bnxt_alloc_vf_filter(bp, vf_id);
+	}
+
+	filter->fw_l2_filter_id = UINT64_MAX;
+	filter->flags = HWRM_CFA_L2_FILTER_ALLOC_INPUT_FLAGS_PATH_RX;
+	filter->enables = HWRM_CFA_L2_FILTER_ALLOC_INPUT_ENABLES_L2_ADDR |
 			HWRM_CFA_L2_FILTER_ALLOC_INPUT_ENABLES_L2_ADDR_MASK;
-	memcpy(filter.l2_addr, addr, ETHER_ADDR_LEN);
-	memset(filter.l2_addr_mask, 0xff, ETHER_ADDR_LEN);
-	rc = bnxt_hwrm_set_filter(bp, vnic.fw_vnic_id, &filter);
+	memcpy(filter->l2_addr, addr, ETHER_ADDR_LEN);
+	memset(filter->l2_addr_mask, 0xff, ETHER_ADDR_LEN);
+	rc = bnxt_hwrm_set_filter(bp, vnic.fw_vnic_id, filter);
 
 exit:
 	return rc;

--- a/drivers/net/bnxt/rte_pmd_bnxt.c
+++ b/drivers/net/bnxt/rte_pmd_bnxt.c
@@ -498,14 +498,12 @@ int rte_pmd_bnxt_mac_addr_add(uint8_t port, struct ether_addr *addr,
 		    && filter->enables == (HWRM_CFA_L2_FILTER_ALLOC_INPUT_ENABLES_L2_ADDR
 		        | HWRM_CFA_L2_FILTER_ALLOC_INPUT_ENABLES_L2_ADDR_MASK)
 		    && memcmp(addr, filter->l2_addr, ETHER_ADDR_LEN) == 0) {
-RTE_LOG(ERR, PMD, "Re-using filter...\n");
 			bnxt_hwrm_clear_filter(bp, filter);
 			break;
 		}
 	}
 
 	if (filter == NULL) {
-RTE_LOG(ERR, PMD, "New filter\n");
 		filter = bnxt_alloc_vf_filter(bp, vf_id);
 	}
 


### PR DESCRIPTION
of constantly allocating more.

Also, re-enable rte_pmd_bnxt_set_all_queues_drop_en() and
rte_pmd_bnxt_set_vf_vlan_anti_spoof().