### PR TITLE
Various VLAN anti-spoof fixes

### DIFF
--- a/drivers/net/bnxt/bnxt_cpr.c
+++ b/drivers/net/bnxt/bnxt_cpr.c
@@ -115,8 +115,11 @@ void bnxt_handle_fwd_req(struct bnxt *bp, struct cmpl_base *cmpl)
 		if (fwd_cmd->req_type == HWRM_CFA_L2_SET_RX_MASK) {
 			struct hwrm_cfa_l2_set_rx_mask_input *srm = (void *)fwd_cmd;
 
-			srm->vlan_tag_tbl_addr = rte_cpu_to_le_64(rte_mem_virt2phy(bp->pf.vf_info[vf_id].vlan_table));
-			srm->num_vlan_tags = rte_cpu_to_le_32((uint32_t)bp->pf.vf_info[vf_id].vlan_count);
+			srm->vlan_tag_tbl_addr = rte_cpu_to_le_64(0);
+			srm->num_vlan_tags = rte_cpu_to_le_32(0);
+			srm->mask &= ~rte_cpu_to_le_32(HWRM_CFA_L2_SET_RX_MASK_INPUT_MASK_VLANONLY |
+			    HWRM_CFA_L2_SET_RX_MASK_INPUT_MASK_VLAN_NONVLAN |
+			    HWRM_CFA_L2_SET_RX_MASK_INPUT_MASK_ANYVLAN_NONVLAN);
 		}
 		/* Forward */
 		rc = bnxt_hwrm_exec_fwd_resp(bp, fw_vf_id, fwd_cmd, req_len);

--- a/drivers/net/bnxt/bnxt_ethdev.c
+++ b/drivers/net/bnxt/bnxt_ethdev.c
@@ -52,6 +52,7 @@
 #include "bnxt_txq.h"
 #include "bnxt_txr.h"
 #include "bnxt_vnic.h"
+#include "rte_pmd_bnxt.h"
 #include "hsi_struct_def_dpdk.h"
 
 #define DRV_MODULE_NAME		"bnxt"
@@ -1134,27 +1135,26 @@ static int bnxt_set_vf_vlan_filter_op(struct rte_eth_dev *dev, uint16_t vlan,
 			if (vlan_on) {
 				/* First, search for a duplicate... */
 				for (j=0; j<bp->pf.vf_info[i].vlan_count; j++) {
-					if (bp->pf.vf_info[i].vlan_table[j].vid == vlan)
+					if (rte_be_to_cpu_16(bp->pf.vf_info[i].vlan_table[j].vid) == vlan)
+						break;
+				}
+				if (j == bp->pf.vf_info[i].vlan_count) {
+					/* Now check that there's space */
+					if (bp->pf.vf_info[i].vlan_count == getpagesize() / sizeof(struct bnxt_vlan_table_entry)) {
+						RTE_LOG(ERR, PMD, "VF %d VLAN table is full, cannot add VLAN %u\n", i, vlan);
+						rc = -1;
 						continue;
-				}
-				if (j < bp->pf.vf_info[i].vlan_count)
-					continue;
+					}
 
-				/* Now check that there's space */
-				if (bp->pf.vf_info[i].vlan_count == getpagesize() / sizeof(struct bnxt_vlan_table_entry)) {
-					RTE_LOG(ERR, PMD, "VF %d VLAN table is full, cannot add VLAN %u\n", i, vlan);
-					rc = -1;
-					continue;
+					/* And finally, add to the end of the table */
+					ve = &bp->pf.vf_info[i].vlan_table[bp->pf.vf_info[i].vlan_count++];
+					ve->tpid = rte_cpu_to_be_16(0x8100);	// TODO: Hardcoded TPID
+					ve->vid = rte_cpu_to_be_16(vlan);
 				}
-
-				/* And finally, add to the end of the table */
-				ve = &bp->pf.vf_info[i].vlan_table[bp->pf.vf_info[i].vlan_count++];
-				ve->tpid = rte_cpu_to_be_16(0x8100);	// TODO: Hardcoded TPID
-				ve->vid = vlan;
 			}
 			else {
 				for (j=0; j<bp->pf.vf_info[i].vlan_count; j++) {
-					if (bp->pf.vf_info[i].vlan_table[j].vid != vlan)
+					if (rte_be_to_cpu_16(bp->pf.vf_info[i].vlan_table[j].vid) != vlan)
 						continue;
 					memmove(&bp->pf.vf_info[i].vlan_table[j], &bp->pf.vf_info[i].vlan_table[j+1],
 					    getpagesize() - ((j+1) * sizeof(struct bnxt_vlan_table_entry)));
@@ -1172,6 +1172,10 @@ static int bnxt_set_vf_vlan_filter_op(struct rte_eth_dev *dev, uint16_t vlan,
 					if (bnxt_hwrm_cfa_l2_set_rx_mask(bp, &vnic, bp->pf.vf_info[i].vlan_count, bp->pf.vf_info[i].vlan_table))
 						rc = -1;
 				}
+			}
+
+			if (bp->pf.vf_info[i].vlan_spoof_en) {
+				rte_pmd_bnxt_set_vf_vlan_anti_spoof(dev->data->port_id, i, bp->pf.vf_info[i].vlan_spoof_en);
 			}
 		}
 	}

--- a/drivers/net/bnxt/bnxt_ethdev.c
+++ b/drivers/net/bnxt/bnxt_ethdev.c
@@ -1119,8 +1119,6 @@ static int bnxt_set_vf_vlan_filter_op(struct rte_eth_dev *dev, uint16_t vlan,
 	struct bnxt *bp = (struct bnxt *)dev->data->dev_private;
 	int i, j;
 	int rc = 0;
-	int dflt_vnic;
-	struct bnxt_vnic_info vnic;
 	struct bnxt_vlan_table_entry *ve;
 
 	if (!bp->pf.vf_info)
@@ -1162,21 +1160,7 @@ static int bnxt_set_vf_vlan_filter_op(struct rte_eth_dev *dev, uint16_t vlan,
 					bp->pf.vf_info[i].vlan_count--;
 				}
 			}
-			dflt_vnic = bnxt_hwrm_func_qcfg_vf_dflt_vnic_id(bp, i);
-			if (dflt_vnic < 0) {
-				// This simply indicates there's no driver loaded.  This is not an error.
-				RTE_LOG(ERR, PMD, "Unable to get default VNIC for VF %d\n", i);
-			}
-			else {
-				if (bnxt_hwrm_vnic_qcfg(bp, &vnic, dflt_vnic) == 0) {
-					if (bnxt_hwrm_cfa_l2_set_rx_mask(bp, &vnic, bp->pf.vf_info[i].vlan_count, bp->pf.vf_info[i].vlan_table))
-						rc = -1;
-				}
-			}
-
-			if (bp->pf.vf_info[i].vlan_spoof_en) {
-				rte_pmd_bnxt_set_vf_vlan_anti_spoof(dev->data->port_id, i, bp->pf.vf_info[i].vlan_spoof_en);
-			}
+			rte_pmd_bnxt_set_vf_vlan_anti_spoof(dev->data->port_id, i, bp->pf.vf_info[i].vlan_spoof_en);
 		}
 	}
 

--- a/drivers/net/bnxt/bnxt_hwrm.c
+++ b/drivers/net/bnxt/bnxt_hwrm.c
@@ -2529,7 +2529,7 @@ int bnxt_hwrm_func_vf_vnic_query_and_config(struct bnxt *bp, uint16_t vf,
 	return rc;
 }
 
-int bnxt_hwrm_func_cfg_vf_set_vlan_anti_spoof(struct bnxt *bp, uint16_t vf)
+int bnxt_hwrm_func_cfg_vf_set_vlan_anti_spoof(struct bnxt *bp, uint16_t vf, bool on)
 {
 	struct hwrm_func_cfg_output *resp = bp->hwrm_cmd_resp_addr;
 	struct hwrm_func_cfg_input req = {0};
@@ -2539,8 +2539,9 @@ int bnxt_hwrm_func_cfg_vf_set_vlan_anti_spoof(struct bnxt *bp, uint16_t vf)
 	req.fid = rte_cpu_to_le_16(bp->pf.vf_info[vf].fid);
 	req.enables |= rte_cpu_to_le_32(
 			HWRM_FUNC_CFG_INPUT_ENABLES_VLAN_ANTISPOOF_MODE);
-	req.vlan_antispoof_mode =
-		HWRM_FUNC_CFG_INPUT_VLAN_ANTISPOOF_MODE_VALIDATE_VLAN;
+	req.vlan_antispoof_mode = on ?
+		HWRM_FUNC_CFG_INPUT_VLAN_ANTISPOOF_MODE_VALIDATE_VLAN :
+		HWRM_FUNC_CFG_INPUT_VLAN_ANTISPOOF_MODE_NOCHECK;
 	rc = bnxt_hwrm_send_message(bp, &req, sizeof(req));
 	HWRM_CHECK_RESULT;
 

--- a/drivers/net/bnxt/bnxt_hwrm.h
+++ b/drivers/net/bnxt/bnxt_hwrm.h
@@ -133,7 +133,7 @@ int bnxt_vf_default_vnic_count(struct bnxt *bp, uint16_t vf);
 int bnxt_hwrm_func_vf_vnic_query_and_config(struct bnxt *bp, uint16_t vf,
 	void (*vnic_cb)(struct bnxt_vnic_info *, void *), void *cbdata,
 	int (*hwrm_cb)(struct bnxt *bp, struct bnxt_vnic_info *vnic));
-int bnxt_hwrm_func_cfg_vf_set_vlan_anti_spoof(struct bnxt *bp, uint16_t vf);
+int bnxt_hwrm_func_cfg_vf_set_vlan_anti_spoof(struct bnxt *bp, uint16_t vf, bool on);
 int bnxt_hwrm_func_qcfg_vf_dflt_vnic_id(struct bnxt *bp, int vf);
 
 #endif


### PR DESCRIPTION
1) We can't have the multicast table from the guest and the vlan
   table from the host.  Instead, mask off VLAN configuration from
   the guest
2) Fix byte order of VLAN ID in table
3) Fix error in duplicate VLAN checking code
4) Always install the VLAN table when VLAN is added
5) Explicitly enable anti-spoof after adding VLAN table