### PR TITLE
Fix check for link.

### DIFF
--- a/drivers/net/bnxt/bnxt_hwrm.c
+++ b/drivers/net/bnxt/bnxt_hwrm.c
@@ -618,7 +618,7 @@ static int bnxt_hwrm_port_phy_qcfg(struct bnxt *bp,
 	HWRM_CHECK_RESULT;
 
 	link_info->phy_link_status = resp->link;
-	if (link_info->phy_link_status != HWRM_PORT_PHY_QCFG_OUTPUT_LINK_NO_LINK) {
+	if (link_info->phy_link_status == HWRM_PORT_PHY_QCFG_OUTPUT_LINK_LINK) {
 		link_info->link_up = 1;
 		link_info->link_speed = rte_le_to_cpu_16(resp->link_speed);
 	} else {


### PR DESCRIPTION
DAC cables can detect there is a signal, but no link.  Code perviously
treated this as link up.