### PR TITLE
Fix mac anti-spoof setting

### DIFF
--- a/drivers/net/bnxt/rte_pmd_bnxt.c
+++ b/drivers/net/bnxt/rte_pmd_bnxt.c
@@ -210,6 +210,8 @@ int rte_pmd_bnxt_set_vf_mac_anti_spoof(uint8_t port, uint16_t vf, uint8_t on)
 		return 0;
 
 	func_flags = bp->pf.vf_info[vf].func_cfg_flags;
+	func_flags &= ~(HWRM_FUNC_CFG_INPUT_FLAGS_SRC_MAC_ADDR_CHECK_ENABLE |
+	    HWRM_FUNC_CFG_INPUT_FLAGS_SRC_MAC_ADDR_CHECK_DISABLE);
 
 	if (on)
 		func_flags |=
@@ -218,11 +220,11 @@ int rte_pmd_bnxt_set_vf_mac_anti_spoof(uint8_t port, uint16_t vf, uint8_t on)
 		func_flags |=
 			HWRM_FUNC_CFG_INPUT_FLAGS_SRC_MAC_ADDR_CHECK_DISABLE;
 
-	bp->pf.vf_info[vf].func_cfg_flags = func_flags;
-
 	rc = bnxt_hwrm_func_cfg_vf_set_flags(bp, vf);
-	if (!rc)
+	if (!rc) {
 		bp->pf.vf_info[vf].mac_spoof_en = on;
+		bp->pf.vf_info[vf].func_cfg_flags = func_flags;
+	}
 
 	return rc;
 }


### PR DESCRIPTION
Clear enable and disable bits before setting one of the two, only
save the modified flags if the HWRM command succeeds.