### PR TITLE
net/bnxt: avoid a regression causing transmits to fail

### DIFF
--- a/drivers/net/bnxt/bnxt_hwrm.c
+++ b/drivers/net/bnxt/bnxt_hwrm.c
@@ -218,14 +218,11 @@ int bnxt_hwrm_cfa_l2_set_rx_mask(struct bnxt *bp, struct bnxt_vnic_info *vnic, u
 	 * by ethtool.
 	 */
 	if (vnic->flags & BNXT_VNIC_INFO_BCAST)
-			mask = HWRM_CFA_L2_SET_RX_MASK_INPUT_MASK_BCAST;
-
+		mask = HWRM_CFA_L2_SET_RX_MASK_INPUT_MASK_BCAST;
 	if (vnic->flags & BNXT_VNIC_INFO_UNTAGGED)
 		mask |= HWRM_CFA_L2_SET_RX_MASK_INPUT_MASK_VLAN_NONVLAN;
-	if (BNXT_VF(bp) || bp->pf.max_vfs) {
-		if (vnic->flags & BNXT_VNIC_INFO_PROMISC)
-			mask |= HWRM_CFA_L2_SET_RX_MASK_INPUT_MASK_PROMISCUOUS;
-	}
+	if (vnic->flags & BNXT_VNIC_INFO_PROMISC)
+		mask |= HWRM_CFA_L2_SET_RX_MASK_INPUT_MASK_PROMISCUOUS;
 	if (vnic->flags & BNXT_VNIC_INFO_ALLMULTI)
 		mask |= HWRM_CFA_L2_SET_RX_MASK_INPUT_MASK_ALL_MCAST;
 	if (vnic->flags & BNXT_VNIC_INFO_MCAST)
@@ -241,11 +238,6 @@ int bnxt_hwrm_cfa_l2_set_rx_mask(struct bnxt *bp, struct bnxt_vnic_info *vnic, u
 	rc = bnxt_hwrm_send_message(bp, &req, sizeof(req));
 
 	HWRM_CHECK_RESULT;
-
-	if (BNXT_PF(bp) && bp->pf.max_vfs == 0) {
-		bnxt_clear_hwrm_vnic_filters(bp, vnic);
-		bnxt_set_hwrm_vnic_filters(bp, vnic);
-	}
 
 	return rc;
 }
@@ -1611,12 +1603,6 @@ int bnxt_set_hwrm_vnic_filters(struct bnxt *bp, struct bnxt_vnic_info *vnic)
 	int rc = 0;
 
 	STAILQ_FOREACH(filter, &vnic->filter, next) {
-		if (filter->mac_index == PROMISC_MAC_INDEX) {
-			if (!(vnic->flags & BNXT_VNIC_INFO_PROMISC))
-				continue;
-			if (BNXT_VF(bp) || bp->pf.max_vfs)
-				continue;
-		}
 		rc = bnxt_hwrm_set_filter(bp, vnic->fw_vnic_id, filter);
 		if (rc)
 			break;

--- a/drivers/net/bnxt/bnxt_rxq.c
+++ b/drivers/net/bnxt/bnxt_rxq.c
@@ -45,8 +45,6 @@
 #include "bnxt_vnic.h"
 #include "hsi_struct_def_dpdk.h"
 
-static int bnxt_rx_default_filters(struct bnxt *bp, struct bnxt_vnic_info *vnic);
-
 /*
  * RX Queues
  */
@@ -63,22 +61,13 @@ static int bnxt_rx_default_filters(struct bnxt *bp, struct bnxt_vnic_info *vnic)
 {
 	struct bnxt_filter_info *filter;
 
-	/* Now the promiscuous filter */
-	filter = bnxt_alloc_filter(bp);
-	if (!filter) {
-		RTE_LOG(ERR, PMD, "L2 Promiscuous filter alloc failed\n");
-		return -ENOMEM;
-	}
-	memset(filter->l2_addr, 0, sizeof(filter->l2_addr));
-	memcpy(filter->l2_addr_mask, "\x01\x00\x00\x00\x00", sizeof(filter->l2_addr_mask));
-	filter->mac_index = PROMISC_MAC_INDEX;
-	STAILQ_INSERT_TAIL(&vnic->filter, filter, next);
 	/* Finally the MAC filter */
 	filter = bnxt_alloc_filter(bp);
 	if (!filter) {
 		RTE_LOG(ERR, PMD, "L2 filter alloc failed\n");
 		return -ENOMEM;
 	}
+	STAILQ_INSERT_TAIL(&vnic->filter, filter, next);
 
 	return 0;
 }


### PR DESCRIPTION
Backing off changes made to improve performance.
These changes are causing a regression due to which Tx fails in
certain configurations. This regression did not impact VFd though.