### PR TITLE
Implement the new hwrm_cfa_vlan_antispoof_cfg command.

### DIFF
--- a/drivers/net/bnxt/bnxt.h
+++ b/drivers/net/bnxt/bnxt.h
@@ -59,9 +59,16 @@ struct bnxt_vlan_table_entry {
 	uint16_t		vid;
 } __attribute__((packed));
 
+struct bnxt_vlan_antispoof_table_entry {
+	uint16_t		tpid;
+	uint16_t		vid;
+	uint16_t		mask;
+} __attribute__((packed));
+
 struct bnxt_child_vf_info {
 	void			*req_buf;
 	struct bnxt_vlan_table_entry	*vlan_table;
+	struct bnxt_vlan_antispoof_table_entry	*vlan_as_table;
 	STAILQ_HEAD(, bnxt_filter_info)	filter;
 	uint32_t		func_cfg_flags;
 	uint32_t		l2_rx_mask;
@@ -177,6 +184,7 @@ struct bnxt {
 	rte_spinlock_t			hwrm_lock;
 	uint16_t			max_req_len;
 	uint16_t			max_resp_len;
+	uint32_t			hwrm_intf_ver;
 
 	struct bnxt_link_info	link_info;
 	struct bnxt_cos_queue_info	cos_queue[BNXT_COS_QUEUE_COUNT];

--- a/drivers/net/bnxt/bnxt_hwrm.c
+++ b/drivers/net/bnxt/bnxt_hwrm.c
@@ -253,9 +253,15 @@ int bnxt_hwrm_cfa_vlan_antispoof_cfg(struct bnxt *bp, uint16_t fid, uint16_t vla
 	 * Older HWRM versions did not support this command, and the set_rx_mask
 	 * list was used for anti-spoof.  In 1.8.0, the TX path configuration was
 	 * removed from set_rx_mask call, and this command was added.
+	 *
+	 * This command is also present from 1.7.8.11 and higher, as well as 1.7.8.0
 	 */
-	if (bp->hwrm_intf_ver < ((1<<24) | (8<<16)))
-		return 0;
+	if (bp->hwrm_intf_ver < ((1<<24) | (8<<16))) {
+		if (bp->hwrm_intf_ver != ((1<<24) | (7<<16) | (8<<8))) {
+			if (bp->hwrm_intf_ver < ((1<<24) | (7<<16) | (8<<8) | (11)))
+				return 0;
+		}
+	}
 	HWRM_PREP(req, CFA_VLAN_ANTISPOOF_CFG, -1, resp);
 	req.fid = rte_cpu_to_le_16(fid);
 
@@ -499,7 +505,7 @@ int bnxt_hwrm_ver_get(struct bnxt *bp)
 	my_version |= HWRM_VERSION_MINOR << 8;
 	my_version |= HWRM_VERSION_UPDATE;
 
-	bp->hwrm_intf_ver = resp->hwrm_intf_maj << 26;
+	bp->hwrm_intf_ver = resp->hwrm_intf_maj << 24;
 	bp->hwrm_intf_ver |= resp->hwrm_intf_min << 16;
 	bp->hwrm_intf_ver |= resp->hwrm_intf_upd << 8;
 	bp->hwrm_intf_ver |= resp->hwrm_intf_rsvd;

--- a/drivers/net/bnxt/bnxt_hwrm.h
+++ b/drivers/net/bnxt/bnxt_hwrm.h
@@ -47,6 +47,8 @@ int bnxt_hwrm_cfa_l2_clear_rx_mask(struct bnxt *bp,
 				   struct bnxt_vnic_info *vnic);
 int bnxt_hwrm_cfa_l2_set_rx_mask(struct bnxt *bp, struct bnxt_vnic_info *vnic, uint16_t vlan_count,
     struct bnxt_vlan_table_entry *vlan_table);
+int bnxt_hwrm_cfa_vlan_antispoof_cfg(struct bnxt *bp, uint16_t fid, uint16_t vlan_count,
+    struct bnxt_vlan_antispoof_table_entry *vlan_table);
 int bnxt_hwrm_clear_filter(struct bnxt *bp,
 			   struct bnxt_filter_info *filter);
 int bnxt_hwrm_set_filter(struct bnxt *bp,

--- a/drivers/net/bnxt/hsi_struct_def_dpdk.h
+++ b/drivers/net/bnxt/hsi_struct_def_dpdk.h
@@ -161,8 +161,7 @@ struct ctx_hw_stats64 {
 #define HWRM_CFA_L2_FILTER_FREE                           (UINT32_C(0x91))
 #define HWRM_CFA_L2_FILTER_CFG                            (UINT32_C(0x92))
 #define HWRM_CFA_L2_SET_RX_MASK                           (UINT32_C(0x93))
-    /* Reserved for future use */
-#define RESERVED4                                         (UINT32_C(0x94))
+#define HWRM_CFA_VLAN_ANTISPOOF_CFG                       (UINT32_C(0x94))
 #define HWRM_CFA_TUNNEL_FILTER_ALLOC                      (UINT32_C(0x95))
 #define HWRM_CFA_TUNNEL_FILTER_FREE                       (UINT32_C(0x96))
 #define HWRM_CFA_NTUPLE_FILTER_ALLOC                      (UINT32_C(0x99))
@@ -7302,6 +7301,85 @@ struct hwrm_cfa_l2_set_rx_mask_output {
 	 * this field is written last.
 	 */
 } __attribute__((packed));
+
+/* hwrm_cfa_vlan_antispoof_cfg */
+/* Description: Configures vlan anti-spoof filters for VF. */
+/* Input (32 bytes) */
+struct hwrm_cfa_vlan_antispoof_cfg_input {
+    uint16_t req_type;
+    /*
+     * This value indicates what type of request this is. The format for the
+     * rest of the command is determined by this field.
+     */
+    uint16_t cmpl_ring;
+    /*
+     * This value indicates the what completion ring the request will be
+     * optionally completed on. If the value is -1, then no CR completion
+     * will be generated. Any other value must be a valid CR ring_id value
+     * for this function.
+     */
+    uint16_t seq_id;
+    /* This value indicates the command sequence number. */
+    uint16_t target_id;
+    /*
+     * Target ID of this command. 0x0 - 0xFFF8 - Used for function ids
+     * 0xFFF8 - 0xFFFE - Reserved for internal processors 0xFFFF - HWRM
+     */
+    uint64_t resp_addr;
+    /*
+     * This is the host address where the response will be written when the
+     * request is complete. This area must be 16B aligned and must be
+     * cleared to zero before the request is made.
+     */
+    uint16_t fid;
+    /*
+     * Function ID of the function that is being configured. Only valid for
+     * a VF FID configured by the PF.
+     */
+    uint8_t unused_0;
+    uint8_t unused_1;
+    uint32_t num_vlan_entries;
+    /* Number of VLAN entries in the vlan_tag_mask_tbl. */
+    uint64_t vlan_tag_mask_tbl_addr;
+    /*
+     * The vlan_tag_mask_tbl_addr is the DMA address of the VLAN antispoof
+     * table. Each table entry contains the 16-bit TPID (0x8100 or 0x88a8
+     * only), 16-bit VLAN ID, and a 16-bit mask, all in network order to
+     * match hwrm_cfa_l2_set_rx_mask. For an individual VLAN entry, the mask
+     * value should be 0xfff for the 12-bit VLAN ID.
+     */
+};
+
+/* Output (16 bytes) */
+struct hwrm_cfa_vlan_antispoof_cfg_output {
+    uint16_t error_code;
+    /*
+     * Pass/Fail or error type Note: receiver to verify the in parameters,
+     * and fail the call with an error when appropriate
+     */
+    uint16_t req_type;
+    /* This field returns the type of original request. */
+    uint16_t seq_id;
+    /* This field provides original sequence number of the command. */
+    uint16_t resp_len;
+    /*
+     * This field is the length of the response in bytes. The last byte of
+     * the response is a valid flag that will read as '1' when the command
+     * has been completely written to memory.
+     */
+    uint32_t unused_0;
+    uint8_t unused_1;
+    uint8_t unused_2;
+    uint8_t unused_3;
+    uint8_t valid;
+    /*
+     * This field is used in Output records to indicate that the output is
+     * completely written to RAM. This field should be read as '1' to
+     * indicate that the output has been completely written. When writing a
+     * command completion or response to an internal processor, the order of
+     * writes has to be such that this field is written last.
+     */
+};
 
 /* hwrm_tunnel_dst_port_alloc */
 /*


### PR DESCRIPTION
This moves the TX path configuration out of set_rx_mask and was
introduced in HWRM version 1.8.0.