### PR TITLE
Fix bug which could set multiple conflicting bits

### DIFF
--- a/drivers/net/bnxt/bnxt_hwrm.c
+++ b/drivers/net/bnxt/bnxt_hwrm.c
@@ -227,8 +227,9 @@ int bnxt_hwrm_cfa_l2_set_rx_mask(struct bnxt *bp, struct bnxt_vnic_info *vnic, u
 		mask |= HWRM_CFA_L2_SET_RX_MASK_INPUT_MASK_ALL_MCAST;
 	if (vnic->flags & BNXT_VNIC_INFO_MCAST)
 		mask |= HWRM_CFA_L2_SET_RX_MASK_INPUT_MASK_MCAST;
-	if (vlan_count && vlan_table) {
-		mask |= HWRM_CFA_L2_SET_RX_MASK_INPUT_MASK_VLANONLY;
+	if (vlan_table) {
+		if (!(mask & HWRM_CFA_L2_SET_RX_MASK_INPUT_MASK_VLAN_NONVLAN))
+			mask |= HWRM_CFA_L2_SET_RX_MASK_INPUT_MASK_VLANONLY;
 		req.vlan_tag_tbl_addr = rte_cpu_to_le_64(rte_mem_virt2phy(vlan_table));
 		req.num_vlan_tags = rte_cpu_to_le_32((uint32_t)vlan_count);
 	}


### PR DESCRIPTION
Only set the vlanonly bit if vlan_nonvlan is clear.  Also, allow the
VLAN table to be cleared when vlanonly is set.

Clearing the VLAN table when vlanonly is set will stop all traffic
since it requires all frames to have a VLAN tag, and that tag to be
in the zero-length table.  This is still a valid use case though,
and has been seen in the wild.